### PR TITLE
Add support for cherrypick

### DIFF
--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/network/nodeinfo/NodeInfoService.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/network/nodeinfo/NodeInfoService.kt
@@ -41,6 +41,7 @@ internal data object NodeInfoService {
         listOf(
             "misskey",
             "sharkey",
+            "cherrypick",
         )
 
     suspend fun fetchNodeInfo(host: String): String? {


### PR DESCRIPTION
CherryPick is a fork of Misskey, and Flare confirmed that the same functionality as Misskey is available.