### PR TITLE
replase emojis request from POST to GET

### DIFF
--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/network/misskey/api/MetaApi.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/network/misskey/api/MetaApi.kt
@@ -3,6 +3,7 @@ package dev.dimension.flare.data.network.misskey.api
 import de.jensklingenberg.ktorfit.Response
 import de.jensklingenberg.ktorfit.http.Body
 import de.jensklingenberg.ktorfit.http.Headers
+import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.POST
 import dev.dimension.flare.data.network.misskey.api.model.AdminInviteCreate200ResponseInner
 import dev.dimension.flare.data.network.misskey.api.model.AdminMeta200Response
@@ -87,10 +88,9 @@ internal interface MetaApi {
      *  - 418: I'm Ai
      *  - 500: Internal server error
      *
-     * @param body * @return [Emojis200Response]
+     * @return [Emojis200Response]
      */
-    @POST("emojis")
-    @Headers(value = ["Content-Type: "])
+    @GET("emojis")
     suspend fun emojis(): Response<Emojis200Response>
 
     /**


### PR DESCRIPTION
Changed api/emojis request to GET instead of POST.
Fix #658 