### PR TITLE
misskey only images(files) renote is quote

### DIFF
--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/mapper/Misskey.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/mapper/Misskey.kt
@@ -161,7 +161,7 @@ private fun List<Note>.toDbPagingTimeline(
             references =
                 listOfNotNull(
                     if (it.renote != null) {
-                        if (it.text.isNullOrEmpty()) {
+                        if (it.text.isNullOrEmpty() && it.files.isNullOrEmpty()) {
                             ReferenceType.Retweet to it.renote.toDbStatusWithUser(accountKey)
                         } else {
                             ReferenceType.Quote to it.renote.toDbStatusWithUser(accountKey)


### PR DESCRIPTION
Misskey quote can be made only in files without entering text.
|Misskey Web|Flare (before)|Flare (after)|
|:-:|:-:|:-:|
|![misskey_renote_image_only](https://github.com/user-attachments/assets/7d5eba2d-4745-4063-b717-842f1c73678e)|![flare_renote_image_only_issue](https://github.com/user-attachments/assets/916cd80f-0dd0-43b8-989a-093a59e6d9d3)|![flare_renote_image_only_fixed](https://github.com/user-attachments/assets/8a25dcc8-7468-4e20-9646-bb2be6ce1dbf)|