### PR TITLE
enable snac support

### DIFF
--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/network/nodeinfo/NodeInfoService.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/network/nodeinfo/NodeInfoService.kt
@@ -46,6 +46,7 @@ internal data object NodeInfoService {
             "mastodon",
             "kmyblue",
             "fedibird",
+            "snac",
         ) + pleromaNodeInfoName
 
     private val misskeyNodeInfoName =


### PR DESCRIPTION
closes #1342
adds snac to the list of valid mastodon node info to get it supported.
I tested on my own (android) phone and (linux) computer, using my vanilla snac instance, it adds a broken default feed, but apart from that, it works as expected.
