### PR TITLE
Prefer `url` over `uri` for share button

### DIFF
--- a/shared/src/commonMain/kotlin/dev/dimension/flare/ui/model/mapper/Mastodon.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/ui/model/mapper/Mastodon.kt
@@ -317,10 +317,10 @@ private fun Status.renderStatus(
         }
     val postUrl =
         buildString {
-            if (!uri.isNullOrEmpty()) {
-                append(uri)
-            } else if (!url.isNullOrEmpty()) {
+            if (!url.isNullOrEmpty()) {
                 append(url)
+            } else if (!uri.isNullOrEmpty()) {
+                append(uri)
             } else {
                 append("https://$host/@${account.acct}/$id")
             }

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/ui/model/mapper/Misskey.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/ui/model/mapper/Misskey.kt
@@ -373,10 +373,10 @@ private fun Note.renderStatus(
             .toPersistentList()
     val postUrl =
         buildString {
-            if (!uri.isNullOrEmpty()) {
-                append(uri)
-            } else if (!url.isNullOrEmpty()) {
+            if (!url.isNullOrEmpty()) {
                 append(url)
+            } else if (!uri.isNullOrEmpty()) {
+                append(uri)
             } else {
                 append("https://")
                 append(accountKey.host)


### PR DESCRIPTION
Posts on Misskey and Mastodon contain both `uri` and `url`. When interacting within these two ActivityPub platforms, there is no significant difference between a post's `uri` and `url`. Accessing them via a web browser includes a redirect from `uri` to `url`, making the difference appear negligible. However, the `uri` returned by Threads and Birdgy Fed (Bluesky &amp; ActivityPub bridge) appear to be specialized for server-to-server processing. As a result, web browsers fail to display the appropriate frontend.

To resolve this issue, I propose changing the behavior to prioritize selecting `url` over `uri` as the link for the share button.