### PR TITLE
Issue 1720: higher contrast reply line

### DIFF
--- a/app/src/main/java/dev/dimension/flare/ui/theme/Theme.kt
+++ b/app/src/main/java/dev/dimension/flare/ui/theme/Theme.kt
@@ -50,7 +50,7 @@ private fun ColorScheme.withPureColorLightMode(): ColorScheme =
         surfaceContainerLowest = Color.White,
         surfaceContainerHighest = Color.White,
         onSurfaceVariant = MoreColors.Gray800,
-        outlineVariant = MoreColors.Gray400,
+        outlineVariant = MoreColors.Gray700,
         outline = MoreColors.Gray600,
     )
 
@@ -66,7 +66,7 @@ private fun ColorScheme.withPureColorDarkMode(): ColorScheme =
         surfaceContainerLowest = MoreColors.Gray900,
         surfaceContainerHighest = MoreColors.Gray900,
         onSurfaceVariant = MoreColors.Gray400,
-        outlineVariant = MoreColors.Gray800,
+        outlineVariant = MoreColors.Gray300,
         outline = MoreColors.Gray500,
     )
 


### PR DESCRIPTION
Per the discussion in [Issue 1720](https://github.com/DimensionDev/Flare/issues/1720), I updated outlineVariant color setting using existing Material colors to be darker in light mode and lighter in dark mode.