### PR TITLE
[Idea] New look for Account Manager.

### DIFF
--- a/app/src/main/java/dev/dimension/flare/ui/screen/settings/AccountsScreen.kt
+++ b/app/src/main/java/dev/dimension/flare/ui/screen/settings/AccountsScreen.kt
@@ -6,12 +6,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.IconButton
@@ -22,18 +21,13 @@ import androidx.compose.material3.ListItemShapes
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.SegmentedListItem
-import androidx.compose.material3.SwipeToDismissBox
-import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -42,7 +36,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import compose.icons.FontAwesomeIcons
 import compose.icons.fontawesomeicons.Solid
-import compose.icons.fontawesomeicons.solid.EllipsisVertical
 import compose.icons.fontawesomeicons.solid.FaceSadTear
 import compose.icons.fontawesomeicons.solid.Plus
 import compose.icons.fontawesomeicons.solid.Trash
@@ -117,100 +110,47 @@ internal fun AccountsScreen(
             state.accounts
                 .onSuccess { accountState ->
                     itemsIndexed(accountState.toImmutableList()) { index, (account, data) ->
-                        val swipeState =
-                            rememberSwipeToDismissBoxState()
                         val shape = ListItemDefaults.segmentedShapes2(index, accountState.size)
-                        var showMenu by remember { mutableStateOf(false) }
-                        val isSwiping =
-                            swipeState.dismissDirection != SwipeToDismissBoxValue.Settled
-                        LaunchedEffect(swipeState.settledValue) {
-                            if (swipeState.settledValue != SwipeToDismissBoxValue.Settled) {
-                                delay(AnimationConstants.DefaultDurationMillis.toLong())
-                                state.logout(account.accountKey)
-                            }
-                        }
-                        SwipeToDismissBox(
-                            state = swipeState,
-                            backgroundContent = {
-                                if (swipeState.dismissDirection != SwipeToDismissBoxValue.Settled) {
-                                    Box(
-                                        modifier =
-                                            Modifier
-                                                .fillMaxSize()
-                                                .background(color = MaterialTheme.colorScheme.error, shape = shape.draggedShape)
-                                                .padding(16.dp),
-                                        contentAlignment = Alignment.CenterEnd,
-                                    ) {
-                                        Text(
-                                            text = stringResource(id = R.string.settings_accounts_remove),
-                                            color = MaterialTheme.colorScheme.onError,
-                                        )
-                                    }
-                                }
-                            },
-                            enableDismissFromStartToEnd = false,
-                            enableDismissFromEndToStart = data.isSuccess || data.isError,
+
+                        // Plain row (no swipe)
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                            modifier = Modifier.padding(vertical = 4.dp)
                         ) {
+                            // Radio button sits left of the rounded account box
+                            data.onSuccess { user ->
+                                state.activeAccount.onSuccess { active ->
+                                    RadioButton(
+                                        selected = active.accountKey == user.key,
+                                        onClick = {
+                                            state.setActiveAccount(user.key)
+                                        },
+                                    )
+                                }
+                            }
                             AccountItem(
-                                selected = isSwiping,
+                                selected = false,
                                 userState = data,
                                 shapes = shape,
                                 onClick = {
                                     state.setActiveAccount(it)
                                 },
-                                onLongClick = {
-                                    showMenu = true
-                                },
+                                onLongClick = null,
                                 toLogin = toLogin,
-                                trailingContent = { user ->
-                                    Row(
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                modifier = Modifier.fillMaxWidth(),
+                                trailingContent = { _ ->
+                                    // show a direct delete button on the right
+                                    IconButton(
+                                        onClick = {
+                                            state.logout(account.accountKey)
+                                        },
                                     ) {
-                                        state.activeAccount.onSuccess {
-                                            RadioButton(
-                                                selected = it.accountKey == user.key,
-                                                onClick = {
-                                                    state.setActiveAccount(user.key)
-                                                },
-                                            )
-                                        }
-                                        IconButton(
-                                            onClick = {
-                                                showMenu = true
-                                            },
-                                        ) {
-                                            FAIcon(
-                                                FontAwesomeIcons.Solid.EllipsisVertical,
-                                                contentDescription = stringResource(id = R.string.more),
-                                            )
-                                            DropdownMenu(
-                                                expanded = showMenu,
-                                                onDismissRequest = {
-                                                    showMenu = false
-                                                },
-                                            ) {
-                                                DropdownMenuItem(
-                                                    text = {
-                                                        Text(
-                                                            text = stringResource(id = R.string.settings_accounts_remove),
-                                                            color = MaterialTheme.colorScheme.error,
-                                                        )
-                                                    },
-                                                    onClick = {
-                                                        showMenu = false
-                                                        state.logout(account.accountKey)
-                                                    },
-                                                    leadingIcon = {
-                                                        FAIcon(
-                                                            imageVector = FontAwesomeIcons.Solid.Trash,
-                                                            contentDescription = stringResource(id = R.string.settings_accounts_remove),
-                                                            tint = MaterialTheme.colorScheme.error,
-                                                        )
-                                                    },
-                                                )
-                                            }
-                                        }
+                                        FAIcon(
+                                            imageVector = FontAwesomeIcons.Solid.Trash,
+                                            contentDescription = stringResource(id = R.string.settings_accounts_remove),
+                                            tint = MaterialTheme.colorScheme.error,
+                                        )
                                     }
                                 },
                             )


### PR DESCRIPTION
I was working on a new idea that needed a per-account settings page and, rather than adding things to the three-dot menu on the right in the existing Account Manager I thought it better to redesign it so that clicking on an account would take you to an Account Settings page, which meant moving the account selection radio button outside of the account box.

After working on that idea for a bit I decided that the change I was proposing should be global rather than per-account so I don't need an Account Settings page yet, but I figure we might one day need it so I thought I'd submit this as a proposed layout change to enable those future changes.  I stuck the delete button on the account box in place of the three-dot menu for now, once there is an Account Settings page I propose that the delete icon be removed and replaced with a bit "Delete Account" button at the bottom of an Account Settings page.