### PR TITLE
feat(ios): enable horizontal swipe navigation between timelines

### DIFF
--- a/iosApp/flare/Common/Notifications.swift
+++ b/iosApp/flare/Common/Notifications.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension Notification.Name {
+    static let scrollToTop = Notification.Name("scrollToTop")
+}

--- a/iosApp/flare/UI/FlareRoot.swift
+++ b/iosApp/flare/UI/FlareRoot.swift
@@ -2,6 +2,26 @@ import SwiftUI
 import KotlinSharedUI
 import SwiftUIBackports
 
+private struct TabKeyKey: EnvironmentKey {
+    static let defaultValue: String? = nil
+}
+
+private struct IsActiveKey: EnvironmentKey {
+    static let defaultValue: Bool = true
+}
+
+extension EnvironmentValues {
+    var tabKey: String? {
+        get { self[TabKeyKey.self] }
+        set { self[TabKeyKey.self] = newValue }
+    }
+    
+    var isActive: Bool {
+        get { self[IsActiveKey.self] }
+        set { self[IsActiveKey.self] = newValue }
+    }
+}
+
 @available(iOS 18.0, *)
 struct FlareRoot: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -11,9 +31,18 @@ struct FlareRoot: View {
     @State var selectedTab: String?
     
     var body: some View {
+        let tabBinding = Binding<String?>(
+            get: { selectedTab },
+            set: { newValue in
+                if newValue == selectedTab {
+                    NotificationCenter.default.post(name: .scrollToTop, object: nil, userInfo: ["tab": newValue ?? ""])
+                }
+                selectedTab = newValue
+            }
+        )
         if !activeAccountPresenter.state.user.isLoading {
             StateView(state: homeTabsPresenter.state.tabs) { tabs in
-                TabView(selection: $selectedTab) {
+                TabView(selection: tabBinding) {
                     if horizontalSizeClass == .regular {
                         ForEach(tabs.primary, id: \.key) { data in
                             let badge = if data is NotificationTabItem || data is AllNotificationTabItem {
@@ -25,6 +54,7 @@ struct FlareRoot: View {
                                 Router { onNavigate in
                                     data.view(onNavigate: onNavigate)
                                 }
+                                .environment(\.tabKey, data.key)
                             } label: {
                                 Label {
                                     TabTitle(title: data.metaData.title)
@@ -39,6 +69,7 @@ struct FlareRoot: View {
                                 Router { onNavigate in
                                     data.view(onNavigate: onNavigate)
                                 }
+                                .environment(\.tabKey, data.key)
                             } label: {
                                 Label {
                                     TabTitle(title: data.metaData.title)
@@ -53,6 +84,7 @@ struct FlareRoot: View {
                                 Router { onNavigate in
                                     profileRoute.view(onNavigate: onNavigate)
                                 }
+                                .environment(\.tabKey, profileRoute.key)
                             } label: {
                                 Label {
                                     TabTitle(title: profileRoute.metaData.title)
@@ -67,6 +99,7 @@ struct FlareRoot: View {
                             Router { _ in
                                 SettingsScreen()
                             }
+                            .environment(\.tabKey, "settings")
                         } label: {
                             Label {
                                 Text("settings_title")
@@ -86,6 +119,7 @@ struct FlareRoot: View {
                                 Router { onNavigate in
                                     data.view(onNavigate: onNavigate)
                                 }
+                                .environment(\.tabKey, data.key)
                             } label: {
                                 Label {
                                     TabTitle(title: data.metaData.title)
@@ -99,6 +133,7 @@ struct FlareRoot: View {
                     if case .success = onEnum(of: activeAccountPresenter.state.user) {
                         Tab(value: "more", role: .search) {
                             SecondaryTabsScreen(tabs: tabs.secondary)
+                                .environment(\.tabKey, "more")
                         } label: {
                             Label {
                                 Text("More")
@@ -137,9 +172,18 @@ struct BackportFlareRoot: View {
     @State var selectedTab: String?
     
     var body: some View {
+        let tabBinding = Binding<String?>(
+            get: { selectedTab },
+            set: { newValue in
+                if newValue == selectedTab {
+                    NotificationCenter.default.post(name: .scrollToTop, object: nil, userInfo: ["tab": newValue ?? ""])
+                }
+                selectedTab = newValue
+            }
+        )
         if !activeAccountPresenter.state.user.isLoading {
             StateView(state: homeTabsPresenter.state.tabs) { tabs in
-                TabView(selection: $selectedTab) {
+                TabView(selection: tabBinding) {
                     if horizontalSizeClass == .regular {
                         ForEach(tabs.primary, id: \.key) { data in
                             let badge = if data is NotificationTabItem || data is AllNotificationTabItem {
@@ -150,6 +194,7 @@ struct BackportFlareRoot: View {
                             Router { onNavigate in
                                 data.view(onNavigate: onNavigate)
                             }
+                            .environment(\.tabKey, data.key)
                             .tabItem {
                                 Label {
                                     TabTitle(title: data.metaData.title)
@@ -164,6 +209,7 @@ struct BackportFlareRoot: View {
                             Router { onNavigate in
                                 data.view(onNavigate: onNavigate)
                             }
+                            .environment(\.tabKey, data.key)
                             .tabItem {
                                 Label {
                                     TabTitle(title: data.metaData.title)
@@ -177,6 +223,7 @@ struct BackportFlareRoot: View {
                             Router { onNavigate in
                                 profileRoute.view(onNavigate: onNavigate)
                             }
+                            .environment(\.tabKey, profileRoute.key)
                             .tabItem {
                                 Label {
                                     TabTitle(title: profileRoute.metaData.title)
@@ -189,6 +236,7 @@ struct BackportFlareRoot: View {
                         Router { _ in
                             SettingsScreen()
                         }
+                        .environment(\.tabKey, "settings")
                         .tabItem {
                             Label {
                                 Text("settings_title")
@@ -207,6 +255,7 @@ struct BackportFlareRoot: View {
                             Router { onNavigate in
                                 data.view(onNavigate: onNavigate)
                             }
+                            .environment(\.tabKey, data.key)
                             .tabItem {
                                 Label {
                                     TabTitle(title: data.metaData.title)
@@ -220,6 +269,7 @@ struct BackportFlareRoot: View {
                     }
                     if case .success = onEnum(of: activeAccountPresenter.state.user) {
                         SecondaryTabsScreen(tabs: tabs.secondary)
+                            .environment(\.tabKey, "more")
                             .tabItem {
                                 Label {
                                     Text("More")

--- a/iosApp/flare/UI/Screen/AntennasListScreen.swift
+++ b/iosApp/flare/UI/Screen/AntennasListScreen.swift
@@ -2,32 +2,45 @@ import SwiftUI
 @preconcurrency import KotlinSharedUI
 
 struct AntennasListScreen: View {
+    @Environment(\.tabKey) private var tabKeyEnv
+    @Environment(\.isActive) private var isActive
     let accountType: AccountType
     @StateObject private var presenter: KotlinPresenter<AntennasListPresenterState>
     var body: some View {
-        List {
-            PagingView(data: presenter.state.data) { item in
-                NavigationLink(
-                    value: Route.timeline(
-                        Misskey.AntennasTimelineTabItem(
-                            antennasId: item.id,
-                            account: accountType,
-                            metaData: TabMetaData(
-                                title: TitleType.Text(content: item.title),
-                                icon: IconType.Material(icon: .list)
+        ScrollViewReader { proxy in
+            List {
+                PagingView(data: presenter.state.data) { item in
+                    NavigationLink(
+                        value: Route.timeline(
+                            Misskey.AntennasTimelineTabItem(
+                                antennasId: item.id,
+                                account: accountType,
+                                metaData: TabMetaData(
+                                    title: TitleType.Text(content: item.title),
+                                    icon: IconType.Material(icon: .list)
+                                )
                             )
                         )
-                    )
-                ) {
-                    UiListView(data: item)
+                    ) {
+                        UiListView(data: item)
+                    }
+                } loadingContent: {
+                    UiListPlaceholder()
                 }
-            } loadingContent: {
-                UiListPlaceholder()
+                .id("top")
             }
-        }
-        .navigationTitle("antennas_lists_title")
-        .refreshable {
-            try? await presenter.state.refreshSuspend()
+            .onReceive(NotificationCenter.default.publisher(for: .scrollToTop)) { notification in
+                let targetTab = notification.userInfo?["tab"] as? String
+                if isActive && (targetTab == nil || targetTab == tabKeyEnv) {
+                    withAnimation {
+                        proxy.scrollTo("top", anchor: .top)
+                    }
+                }
+            }
+            .navigationTitle("antennas_lists_title")
+            .refreshable {
+                try? await presenter.state.refreshSuspend()
+            }
         }
     }
 }

--- a/iosApp/flare/UI/Screen/HomeTimelineScreen.swift
+++ b/iosApp/flare/UI/Screen/HomeTimelineScreen.swift
@@ -8,7 +8,7 @@ struct HomeTimelineScreen: View {
     let toTabSetting: () -> Void
     let accountType: AccountType
     @Environment(\.openURL) private var openURL
-    @State private var selectedTabIndex = 0
+    @State private var selectedTabIndex: Int? = 0
     @StateObject private var presenter: KotlinPresenter<HomeTimelineWithTabsPresenterState>
 
     init(accountType: AccountType, toServiceSelect: @escaping () -> Void, toCompose: @escaping () -> Void, toTabSetting: @escaping () -> Void) {
@@ -20,86 +20,91 @@ struct HomeTimelineScreen: View {
     }
 
     var body: some View {
-        GeometryReader { proxy in
-            StateView(state: presenter.state.tabState) { state in
-                let tabs: [TimelineTabItem] = state.cast(TimelineTabItem.self)
-                TabView(selection: $selectedTabIndex) {
+        StateView(state: presenter.state.tabState) { state in
+            let tabs: [TimelineTabItem] = state.cast(TimelineTabItem.self)
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(spacing: 0) {
                     ForEach(0..<tabs.count, id: \.self) { index in
                         TimelineScreen(tabItem: tabs[index])
-                            .tag(index)
+                            .containerRelativeFrame(.horizontal)
+                            .id(index)
+                            .environment(\.isActive, selectedTabIndex == index)
                     }
                 }
-                .tabViewStyle(.page(indexDisplayMode: .never))
-                .onChange(of: state.count, { oldValue, newValue in
-                    if !(tabs.indices.contains(selectedTabIndex)) {
-                        selectedTabIndex = 0
-                    }
-                })
-                .toolbar {
-                    let placement = if #available(iOS 26.0, *) {
-                        ToolbarItemPlacement.automatic
-                    } else {
-                        ToolbarItemPlacement.title
-                    }
-                    ToolbarItem(placement: placement) {
-                        ScrollView(.horizontal) {
-                            HStack(
-                                spacing: 8,
-                            ) {
-                                ForEach(0..<tabs.count, id: \.self) { index in
-                                    let tab = tabs[index]
-                                    Label {
-                                        TabTitle(title: tab.metaData.title)
-                                            .font(.subheadline)
-                                    } icon: {
-                                        TabIcon(icon: tab.metaData.icon, accountType: tab.account, size: 20)
-                                    }
-                                    .onTapGesture {
-                                        withAnimation(.spring) {
-                                            selectedTabIndex = index
-                                        }
-                                    }
-                                    .padding(.horizontal)
-                                    .padding(.vertical, 8)
-                                    .foregroundStyle(selectedTabIndex == index ? Color.white : .primary)
-                                    .backport
-                                    .glassEffect(selectedTabIndex == index ? .tinted(.accentColor) : .regular, in: .capsule, fallbackBackground: selectedTabIndex == index ? Color.accentColor : Color(.systemBackground))
-                                }
-                                Button {
-                                    toTabSetting()
-                                } label: {
-                                    Image("fa-plus")
-                                }
-                                .backport
-                                .glassButtonStyle()
-                            }
-//                            .padding(.horizontal)
-                            .padding(.vertical, 8)
-                        }
-                        .scrollIndicators(.hidden)
-                    }
-                    if #available(iOS 26.0, *) {
-                        ToolbarSpacer(.fixed)
-                    }
-                    ToolbarItem(placement: .primaryAction) {
-                        if case .error = onEnum(of: presenter.state.user) {
-                            Button {
-                                toServiceSelect()
-                            } label: {
-                                Text("Login")
-                            }
-                        } else {
-                            Button {
-                                toCompose()
-                            } label: {
-                                Image("fa-pen-to-square")
-                                    .font(.title2)
-                            }
-                        }
-                    }
-                }
-                .navigationBarTitleDisplayMode(.inline)
+                .scrollTargetLayout()
             }
+            .scrollPosition(id: $selectedTabIndex)
+            .scrollTargetBehavior(.paging)
+            .scrollClipDisabled()
+            .onChange(of: state.count, { oldValue, newValue in
+                if let index = selectedTabIndex, !(tabs.indices.contains(index)) {
+                    selectedTabIndex = 0
+                }
+            })
+            .toolbar {
+                let placement = if #available(iOS 26.0, *) {
+                    ToolbarItemPlacement.automatic
+                } else {
+                    ToolbarItemPlacement.title
+                }
+                ToolbarItem(placement: placement) {
+                    ScrollView(.horizontal) {
+                        HStack(
+                            spacing: 8,
+                        ) {
+                            ForEach(0..<tabs.count, id: \.self) { index in
+                                let tab = tabs[index]
+                                Label {
+                                    TabTitle(title: tab.metaData.title)
+                                        .font(.subheadline)
+                                } icon: {
+                                    TabIcon(icon: tab.metaData.icon, accountType: tab.account, size: 20)
+                                }
+                                .onTapGesture {
+                                    withAnimation(.spring) {
+                                        selectedTabIndex = index
+                                    }
+                                }
+                                .padding(.horizontal)
+                                .padding(.vertical, 8)
+                                .foregroundStyle(selectedTabIndex == index ? Color.white : .primary)
+                                .backport
+                                .glassEffect(selectedTabIndex == index ? .tinted(.accentColor) : .regular, in: .capsule, fallbackBackground: selectedTabIndex == index ? Color.accentColor : Color(.systemBackground))
+                            }
+                            Button {
+                                toTabSetting()
+                            } label: {
+                                Image("fa-plus")
+                            }
+                            .backport
+                            .glassButtonStyle()
+                        }
+//                            .padding(.horizontal)
+                        .padding(.vertical, 8)
+                    }
+                    .scrollIndicators(.hidden)
+                }
+                if #available(iOS 26.0, *) {
+                    ToolbarSpacer(.fixed)
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    if case .error = onEnum(of: presenter.state.user) {
+                        Button {
+                            toServiceSelect()
+                        } label: {
+                            Text("Login")
+                        }
+                    } else {
+                        Button {
+                            toCompose()
+                        } label: {
+                            Image("fa-pen-to-square")
+                                .font(.title2)
+                        }
+                    }
+                }
+            }
+            .navigationBarTitleDisplayMode(.inline)
         }
     }
 }

--- a/iosApp/flare/UI/Screen/ProfileScreen.swift
+++ b/iosApp/flare/UI/Screen/ProfileScreen.swift
@@ -94,21 +94,15 @@ struct ProfileScreen: View {
             .frame(width: 400)
             StateView(state: presenter.state.tabs) { tabsArray in
                 let tabs = tabsArray.cast(ProfileState.Tab.self)
-                TabView(selection: $selectedTab) {
-                    ForEach(0..<tabs.count, id: \.self) { index in
-                        let selectedTabItem = tabs[index]
-                        Group {
-                            switch onEnum(of: selectedTabItem) {
-                            case .timeline(let timeline):
-                                ProfileTimelineWaterFallView(presenter: timeline.presenter)
-                            case .media(let media):
-                                ProfileTimelineWaterFallView(presenter: media.presenter.getMediaTimelinePresenter())
-                            }
-                        }
-                        .tag(index)
-                    }
+                let selectedTabItem = tabs[selectedTab]
+                switch onEnum(of: selectedTabItem) {
+                case .timeline(let timeline):
+                    ProfileTimelineWaterFallView(presenter: timeline.presenter)
+                        .id(timeline.type.name)
+                case .media(let media):
+                    ProfileTimelineWaterFallView(presenter: media.presenter.getMediaTimelinePresenter())
+                        .id("media")
                 }
-                .tabViewStyle(.page(indexDisplayMode: .never))
             }
         }
     }
@@ -153,22 +147,15 @@ struct ProfileScreen: View {
                 .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
                 .padding()
                 .listRowBackground(Color.clear)
-                TabView(selection: $selectedTab) {
-                    ForEach(0..<tabs.count, id: \.self) { index in
-                        let selectedTabItem = tabs[index]
-                        Group {
-                            switch onEnum(of: selectedTabItem) {
-                            case .timeline(let timeline):
-                                ProfileTimelineView(presenter: timeline.presenter)
-                            case .media(let media):
-                                ProfileTimelineView(presenter: media.presenter.getMediaTimelinePresenter())
-                            }
-                        }
-                        .tag(index)
-                    }
+                let selectedTabItem = tabs[selectedTab]
+                switch onEnum(of: selectedTabItem) {
+                case .timeline(let timeline):
+                    ProfileTimelineView(presenter: timeline.presenter)
+                        .id(timeline.type.name)
+                case .media(let media):
+                    ProfileTimelineView(presenter: media.presenter.getMediaTimelinePresenter())
+                        .id("media")
                 }
-                .tabViewStyle(.page(indexDisplayMode: .never))
-                .frame(minHeight: 600) // Ensure TabView has height inside List
             }
         }
         .detectScrolling()

--- a/iosApp/flare/UI/Screen/RssScreen.swift
+++ b/iosApp/flare/UI/Screen/RssScreen.swift
@@ -3,95 +3,120 @@ import KotlinSharedUI
 import UniformTypeIdentifiers
 
 struct RssScreen: View {
+    @Environment(\.tabKey) private var tabKeyEnv
+    @Environment(\.isActive) private var isActive
     @StateObject private var presenter = KotlinPresenter(presenter: RssListWithTabsPresenter())
     @State private var showAddSheet = false
     @State private var selectedEditItem: UiRssSource? = nil
     @State private var importOpmlUrl: URL? = nil
     @State private var exportedOPMLContent: String? = nil
-    var body: some View {
-        List {
-            ForEach(presenter.state.sources, id: \.id) { item in
-                NavigationLink(value: Route.timeline(RssTimelineTabItem(data: item))) {
-                    HStack {
-                        UiRssView(data: item)
-                        Spacer()
-                        Button {
-                            selectedEditItem = item
-                        } label: {
-                            Image("fa-pen")
-                        }
-                        .buttonStyle(.plain)
-                    }
-                }
-                .swipeActions {
-                    Button(role: .destructive) {
-                    } label: {
-                        Label {
-                            Text("delete")
-                        } icon: {
-                            Image("fa-trash")
-                        }
 
-                    }
-                }
-            }
-        }
-        .navigationTitle("rss_title")
-        .toolbar {
-            if !presenter.state.sources.isEmpty {
-                ToolbarItem {
-                    Button {
-                        Task {
-                            exportedOPMLContent = try? await ExportOPMLPresenter().export()
-                        }
-                    } label: {
-                        Image("fa-file-export")
-                    }
-                    .fileExporter(
-                        isPresented: Binding(
-                            get: { exportedOPMLContent != nil },
-                            set: { newValue in
-                                if !newValue {
-                                    exportedOPMLContent = nil
-                                }
+    var body: some View {
+        ScrollViewReader { proxy in
+            List {
+                ForEach(presenter.state.sources, id: \.id) { item in
+                    NavigationLink(value: Route.timeline(RssTimelineTabItem(data: item))) {
+                        HStack {
+                            UiRssView(data: item)
+                            Spacer()
+                            Button {
+                                selectedEditItem = item
+                            } label: {
+                                Image("fa-pen")
                             }
-                        ),
-                        document: OPMLFile(initialText: exportedOPMLContent ?? ""),
-                        defaultFilename: "flare_export.opml"
-                    ) { result in
-                        exportedOPMLContent = nil
+                            .buttonStyle(.plain)
+                        }
                     }
-                    
+                    .id(item.id == presenter.state.sources.first?.id ? "top" : "\(item.id)")
+                    .swipeActions {
+                        Button(role: .destructive) {
+                        } label: {
+                            Label {
+                                Text("delete")
+                            } icon: {
+                                Image("fa-trash")
+                            }
+                        }
+                    }
                 }
             }
-            
-            ToolbarItem(placement: .primaryAction) {
+            .onReceive(NotificationCenter.default.publisher(for: .scrollToTop)) { notification in
+                let targetTab = notification.userInfo?["tab"] as? String
+                if isActive && (targetTab == nil || targetTab == tabKeyEnv) {
+                    withAnimation {
+                        proxy.scrollTo("top", anchor: .top)
+                    }
+                }
+            }
+            .navigationTitle("rss_title")
+            .toolbar {
+                toolbarContent
+            }
+            .sheet(isPresented: $showAddSheet) {
+                addSheet
+            }
+            .sheet(item: $selectedEditItem) { item in
+                editSheet(item: item)
+            }
+            .sheet(item: $importOpmlUrl) { url in
+                importSheet(url: url)
+            }
+        }
+    }
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItem {
+            if !presenter.state.sources.isEmpty {
                 Button {
-                    showAddSheet = true
+                    Task {
+                        exportedOPMLContent = try? await ExportOPMLPresenter().export()
+                    }
                 } label: {
-                    Image("fa-plus")
+                    Image("fa-file-export")
+                }
+                .fileExporter(
+                    isPresented: Binding(
+                        get: { exportedOPMLContent != nil },
+                        set: { if !$0 { exportedOPMLContent = nil } }
+                    ),
+                    document: OPMLFile(initialText: exportedOPMLContent ?? ""),
+                    defaultFilename: "flare_export.opml"
+                ) { result in
+                    exportedOPMLContent = nil
                 }
             }
         }
-        .sheet(isPresented: $showAddSheet) {
-            NavigationStack {
-                EditRssSheet(id: nil, onImportOPML: { url in
-                    showAddSheet = false
-                    importOpmlUrl = url
-                })
+        
+        ToolbarItem(placement: .primaryAction) {
+            Button {
+                showAddSheet = true
+            } label: {
+                Image("fa-plus")
             }
         }
-        .sheet(item: $selectedEditItem) { item in
-            NavigationStack {
-                EditRssSheet(id: Int(item.id), initialUrl: item.url, onImportOPML: { url in
-                    importOpmlUrl = url
-                })
-            }
+    }
+
+    private var addSheet: some View {
+        NavigationStack {
+            EditRssSheet(id: nil, onImportOPML: { url in
+                showAddSheet = false
+                importOpmlUrl = url
+            })
         }
-        .sheet(item: $importOpmlUrl) { url in
-            NavigationStack {
-                ImportOPMLScreen(url: url)
-            }
+    }
+
+    private func editSheet(item: UiRssSource) -> some View {
+        NavigationStack {
+            EditRssSheet(id: Int(item.id), initialUrl: item.url, onImportOPML: { url in
+                importOpmlUrl = url
+            })
+        }
+    }
+
+    private func importSheet(url: URL) -> some View {
+        NavigationStack {
+            ImportOPMLScreen(url: url)
         }
     }
 }
@@ -99,6 +124,7 @@ struct RssScreen: View {
 struct EditRssSheet: View {
     @Environment(\.dismiss) private var dismiss
     let id: Int?
+    let initialUrl: String?
     let onImportOPML: (URL) -> Void
     private let publicRssHubServer = [
         "https://rsshub.rssforever.com",
@@ -112,6 +138,14 @@ struct EditRssSheet: View {
     @State private var openInApp: Bool = true
     @State private var selectedRssSources: [UiRssSource] = []
     @State private var showFileImporter = false
+
+    init(id: Int?, initialUrl: String? = nil, onImportOPML: @escaping (URL) -> Void) {
+        self.id = id
+        self.initialUrl = initialUrl
+        self.onImportOPML = onImportOPML
+        self._presenter = .init(wrappedValue: .init(presenter: EditRssSourcePresenter(id: id == nil ? nil : KotlinInt(value: Int32(id!)))))
+    }
+
     var body: some View {
         Form {
             Section {
@@ -119,20 +153,7 @@ struct EditRssSheet: View {
                     .textContentType(.URL)
                     .keyboardType(.URL)
                     .safeAreaInset(edge: .trailing) {
-                        StateView(state: presenter.state.checkState) { state in
-                            switch onEnum(of: state) {
-                            case .rssFeed:
-                                Image("fa-circle-check").foregroundColor(.green)
-                            case .rssHub:
-                                Image("fa-circle-chevron-down").foregroundColor(.secondary)
-                            case .rssSources:
-                                Image("fa-circle-chevron-down").foregroundColor(.secondary)
-                            }
-                        } errorContent: { _ in
-                            Image("fa-circle-exclamation").foregroundColor(.red)
-                        } loadingContent: {
-                            ProgressView().frame(width: 20, height: 20)
-                        }
+                        checkIcon
                     }
                     .onChange(of: url) { oldValue, newValue in
                         presenter.state.checkUrl(value: newValue)
@@ -164,114 +185,9 @@ struct EditRssSheet: View {
                 }
             }
             StateView(state: presenter.state.checkState) { state in
-                switch onEnum(of: state) {
-                case .rssFeed(let rssFeed):
-                    Section {
-                        TextField(text: $title) {
-                            Text("rss_item_title")
-                        }
-                        .safeAreaInset(edge: .leading) {
-                            if let favIcon = rssFeed.icon, !favIcon.isEmpty {
-                                NetworkImage(data: favIcon)
-                                    .frame(width: 24, height: 24)
-                            } else {
-                                Image("fa-square-rss")
-                            }
-                        }
-                        Text(rssFeed.url)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    } header: {
-                        Text("rss_feed_header")
-                    }
-                case .rssSources(let rssSources):
-                    Section {
-                        ForEach(rssSources.sources, id: \.url) { item in
-                            HStack {
-                                UiRssView(data: item)
-                                Spacer()
-                                if selectedRssSources.contains(where: { $0.url == item.url }) {
-                                    Image(systemName: "checkmark.circle.fill")
-                                        .foregroundColor(.blue)
-                                } else {
-                                    Image(systemName: "circle")
-                                        .foregroundColor(.blue)
-                                }
-                            }
-                            .onTapGesture {
-                                if let index = selectedRssSources.firstIndex(where: { $0.url == item.url }) {
-                                    selectedRssSources.remove(at: index)
-                                } else {
-                                    selectedRssSources.append(item)
-                                }
-                            }
-                        }
-                    } header: {
-                        Text("rss_sources_header")
-                    }
-                case .rssHub:
-                    Section {
-                        TextField(text: $title) {
-                            Text("rss_item_title")
-                        }
-                        TextField(text: $rssHubHost) {
-                            Text("rss_hub_host_placeholder")
-                        }
-                        .textContentType(.URL)
-                        .keyboardType(.URL)
-                        .safeAreaInset(edge: .trailing) {
-                            StateView(state: presenter.state.inputState) { inputState in
-                                if case .rssHub(let rssHub) = onEnum(of: inputState) {
-                                    StateView(state: rssHub.checkState) { _ in
-                                        Image("fa-circle-check").foregroundColor(.green)
-                                    } errorContent : { _ in
-                                        Image("fa-circle-exclamation").foregroundColor(.red)
-                                    } loadingContent: {
-                                        ProgressView().frame(width: 20, height: 20)
-                                    }
-                                }
-                            }
-                        }
-                        .onChange(of: presenter.state.inputState, { oldValue, newValue in
-                            print("Input state changed: \(newValue)")
-                            if case .success(let success) = onEnum(of: newValue),
-                               case .rssHub(let rssHubState) = onEnum(of: success.data),
-                               case .success(let checkSuccess) = onEnum(of: rssHubState.checkState),
-                               case .rssFeed(let feed) = onEnum(of: checkSuccess.data) {
-                                title = feed.title
-                            }
-                        })
-                        .onChange(of: rssHubHost) { oldValue, newValue in
-                            if case .success(let inputState) = onEnum(of: presenter.state.inputState) {
-                                if case .rssHub(let rssHub) = onEnum(of: inputState.data) {
-                                    rssHub.checkWithServer(server: rssHubHost)
-                                }
-                            }
-                        }
-                    } header: {
-                        Text("rss_hub_header")
-                    }
-                    
-                    Section {
-                        ForEach(publicRssHubServer, id: \.self) { server in
-                            Text(server)
-                                .onTapGesture {
-                                    rssHubHost = server
-                                }
-                        }
-                    } header: {
-                        Text("rss_hub_server_header")
-                    }
-                }
-                
-                Section {
-                    Picker("rss_open_in", selection: $openInApp) {
-                        Text("rss_open_in_app").tag(true)
-                        Text("rss_open_in_browser").tag(false)
-                    }
-                }
+                checkResultView(state: state)
             }
-         }
+        }
         .onChange(of: presenter.state.checkState, { oldValue, newValue in
             selectedRssSources = []
             rssHubHost = ""
@@ -289,63 +205,150 @@ struct EditRssSheet: View {
         .navigationTitle(id == nil ? "add_rss_title" : "edit_rss_title")
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
-                Button(
-                    role: .cancel
-                ) {
+                Button(role: .cancel) {
                     dismiss()
                 } label: {
-                    Label {
-                        Text("Cancel")
-                    } icon: {
-                        Image("fa-xmark")
-                    }
+                    Label { Text("Cancel") } icon: { Image("fa-xmark") }
                 }
             }
             ToolbarItem(placement: .confirmationAction) {
-                Button(
-//                    role: .confirm
-                ) {
-                    if case .success(let success) = onEnum(of: presenter.state.inputState) {
-                        switch onEnum(of: success.data) {
-                        case .rssFeed(let feed):
-                            feed.save(title: title, openInBrowser: !openInApp)
-                        case .rssHub(let rssHub):
-                            rssHub.save(title: title, openInBrowser: !openInApp)
-                        case .rssSources(let rssSources):
-                            rssSources.save(sources: selectedRssSources, openInBrowser: !openInApp)
-                        }
-                    }
+                Button {
+                    saveAction()
                     dismiss()
                 } label: {
-                    Label {
-                        Text("Done")
-                    } icon: {
-                        Image("fa-check")
-                    }
+                    Label { Text("Done") } icon: { Image("fa-check") }
                 }
             }
         }
         .onAppear {
-            if !self.url.isEmpty {
-                presenter.state.checkUrl(value: self.url)
+            if let initialUrl = initialUrl, !initialUrl.isEmpty {
+                self.url = initialUrl
+                presenter.state.checkUrl(value: initialUrl)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var checkIcon: some View {
+        StateView(state: presenter.state.checkState) { (state: CheckRssSourcePresenterStateRssState) in
+            switch onEnum(of: state) {
+            case .rssFeed:
+                Image("fa-circle-check").foregroundColor(.green)
+            case .rssHub, .rssSources:
+                Image("fa-circle-chevron-down").foregroundColor(.secondary)
+            }
+        } errorContent: { _ in
+            Image("fa-circle-exclamation").foregroundColor(.red)
+        } loadingContent: {
+            ProgressView().frame(width: 20, height: 20)
+        }
+    }
+
+    @ViewBuilder
+    private func checkResultView(state: CheckRssSourcePresenterStateRssState) -> some View {
+        Group {
+            switch onEnum(of: state) {
+            case .rssFeed(let rssFeed):
+                Section {
+                    TextField(text: $title) { Text("rss_item_title") }
+                    .safeAreaInset(edge: .leading) {
+                        if let favIcon = rssFeed.icon, !favIcon.isEmpty {
+                            NetworkImage(data: favIcon).frame(width: 24, height: 24)
+                        } else {
+                            Image("fa-square-rss")
+                        }
+                    }
+                    Text(rssFeed.url).font(.caption).foregroundStyle(.secondary)
+                } header: { Text("rss_feed_header") }
+            case .rssSources(let rssSources):
+                Section {
+                    ForEach(rssSources.sources, id: \.url) { item in
+                        HStack {
+                            UiRssView(data: item)
+                            Spacer()
+                            Image(systemName: selectedRssSources.contains(where: { $0.url == item.url }) ? "checkmark.circle.fill" : "circle")
+                                .foregroundColor(.blue)
+                        }
+                        .onTapGesture {
+                            if let index = selectedRssSources.firstIndex(where: { $0.url == item.url }) {
+                                selectedRssSources.remove(at: index)
+                            } else {
+                                selectedRssSources.append(item)
+                            }
+                        }
+                    }
+                } header: { Text("rss_sources_header") }
+            case .rssHub:
+                rssHubSection
+            }
+            
+            Section {
+                Picker("rss_open_in", selection: $openInApp) {
+                    Text("rss_open_in_app").tag(true)
+                    Text("rss_open_in_browser").tag(false)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var rssHubSection: some View {
+        Section {
+            TextField(text: $title) { Text("rss_item_title") }
+            TextField(text: $rssHubHost) { Text("rss_hub_host_placeholder") }
+            .textContentType(.URL).keyboardType(.URL)
+            .safeAreaInset(edge: .trailing) {
+                StateView(state: presenter.state.inputState) { inputState in
+                    if case .rssHub(let rssHub) = onEnum(of: inputState) {
+                        StateView(state: rssHub.checkState) { _ in
+                            Image("fa-circle-check").foregroundColor(.green)
+                        } errorContent : { _ in
+                            Image("fa-circle-exclamation").foregroundColor(.red)
+                        } loadingContent: {
+                            ProgressView().frame(width: 20, height: 20)
+                        }
+                    }
+                }
+            }
+            .onChange(of: presenter.state.inputState, { oldValue, newValue in
+                if case .success(let success) = onEnum(of: newValue),
+                   case .rssHub(let rssHubState) = onEnum(of: success.data),
+                   case .success(let checkSuccess) = onEnum(of: rssHubState.checkState),
+                   case .rssFeed(let feed) = onEnum(of: checkSuccess.data) {
+                    title = feed.title
+                }
+            })
+            .onChange(of: rssHubHost) { oldValue, newValue in
+                if case .success(let inputState) = onEnum(of: presenter.state.inputState) {
+                    if case .rssHub(let rssHub) = onEnum(of: inputState.data) {
+                        rssHub.checkWithServer(server: rssHubHost)
+                    }
+                }
+            }
+        } header: { Text("rss_hub_header") }
+        
+        Section {
+            ForEach(publicRssHubServer, id: \.self) { server in
+                Text(server).onTapGesture { rssHubHost = server }
+            }
+        } header: { Text("rss_hub_server_header") }
+    }
+
+    private func saveAction() {
+        if case .success(let success) = onEnum(of: presenter.state.inputState) {
+            switch onEnum(of: success.data) {
+            case .rssFeed(let feed):
+                feed.save(title: title, openInBrowser: !openInApp)
+            case .rssHub(let rssHub):
+                rssHub.save(title: title, openInBrowser: !openInApp)
+            case .rssSources(let rssSources):
+                rssSources.save(sources: selectedRssSources, openInBrowser: !openInApp)
             }
         }
     }
 }
 
-extension EditRssSheet {
-    init(id: Int?, initialUrl: String? = nil, onImportOPML: @escaping (URL) -> Void) {
-        self.id = id
-        self.onImportOPML = onImportOPML
-        self.url = initialUrl ?? ""
-        self._presenter = .init(wrappedValue: .init(presenter: EditRssSourcePresenter(id: id == nil ? nil : KotlinInt(value: Int32(id!)))))
-    }
-}
-
-extension UiRssSource: Identifiable {
-    
-}
-
+extension UiRssSource: Identifiable {}
 extension URL: Identifiable {
     public var id: String { absoluteString }
 }

--- a/iosApp/flare/UI/Screen/SettingsScreen.swift
+++ b/iosApp/flare/UI/Screen/SettingsScreen.swift
@@ -2,122 +2,126 @@ import SwiftUI
 import KotlinSharedUI
 
 struct SettingsScreen: View {
+    @Environment(\.tabKey) private var tabKeyEnv
+    @Environment(\.isActive) private var isActive
     @StateObject private var presenter = KotlinPresenter(presenter: ActiveAccountPresenter())
 
     var body: some View {
-        List {
-            StateView(state: presenter.state.user) { user in
-                if #available(iOS 26.0, *) {
-                    NavigationLink(value: Route.accountManagement) {
-                        Label {
-                            Text("account_management_title")
-                            Text("account_management_description")
-                        } icon: {
-                            AvatarView(data: user.avatar)
-                                .frame(width: 44, height: 44)
+        ScrollViewReader { proxy in
+            List {
+                Group {
+                    StateView(state: presenter.state.user) { user in
+                        if #available(iOS 26.0, *) {
+                            NavigationLink(value: Route.accountManagement) {
+                                Label {
+                                    Text("account_management_title")
+                                    Text("account_management_description")
+                                } icon: {
+                                    AvatarView(data: user.avatar)
+                                        .frame(width: 44, height: 44)
+                                }
+                                .labelReservedIconWidth(44)
+                            }
+                        } else {
+                            NavigationLink(value: Route.accountManagement) {
+                                Label {
+                                    Text("account_management_title")
+                                    Text("account_management_description")
+                                } icon: {
+                                    AvatarView(data: user.avatar)
+                                        .frame(width: 20, height: 20)
+                                }
+                            }
                         }
-                        .labelReservedIconWidth(44)
                     }
-                } else {
-                    NavigationLink(value: Route.accountManagement) {
+                }
+                .id("top")
+
+                Section {
+                    NavigationLink(value: Route.appearance) {
                         Label {
-                            Text("account_management_title")
-                            Text("account_management_description")
+                            Text("appearance_title")
+                            Text("appearance_description")
                         } icon: {
-                            AvatarView(data: user.avatar)
-                                .frame(width: 20, height: 20)
+                            Image("fa-palette")
+                        }
+                    }
+                    if let url = URL(string: UIApplication.openSettingsURLString) {
+                        Link(destination: url) {
+                            Label {
+                                Text("system_settings_title")
+                                Text("system_settings_description")
+                            } icon: {
+                                Image(.faGear)
+                            }
+                        }
+                    }
+                }
+
+                Section {
+                    StateView(state: presenter.state.user) { _ in
+                        NavigationLink(value: Route.localFilter) {
+                            Label {
+                                Text("local_filter_title")
+                                Text("local_filter_description")
+                            } icon: {
+                                Image("fa-filter")
+                            }
+                        }
+                        NavigationLink(value: Route.localHostory) {
+                            Label {
+                                Text("local_history_title")
+                                Text("local_history_description")
+                            } icon: {
+                                Image("fa-clock-rotate-left")
+                            }
+                        }
+                    }
+                    NavigationLink(value: Route.rssManagement) {
+                        Label {
+                            Text("settings_rss_management_title")
+                            Text("settings_rss_management_description")
+                        } icon: {
+                            Image("fa-square-rss")
+                        }
+                    }
+                    NavigationLink(value: Route.storage) {
+                        Label {
+                            Text("storage_title")
+                            Text("storage_description")
+                        } icon: {
+                            Image("fa-database")
+                        }
+                    }
+                }
+
+                Section {
+                    NavigationLink(value: Route.aiConfig) {
+                        Label {
+                            Text("ai_config_title")
+                            Text("ai_config_description")
+                        } icon: {
+                            Image("fa-robot")
+                        }
+                    }
+                }
+
+                Section {
+                    NavigationLink(value: Route.about) {
+                        Label {
+                            Text("about_title")
+                            Text("about_description")
+                        } icon: {
+                            Image("fa-circle-info")
                         }
                     }
                 }
             }
-
-            Section {
-                NavigationLink(value: Route.appearance) {
-                    Label {
-                        Text("appearance_title")
-                        Text("appearance_description")
-                    } icon: {
-                        Image("fa-palette")
-                    }
-                }
-                if let url = URL(string: UIApplication.openSettingsURLString) {
-                    Link(destination: url) {
-                        Label {
-                            Text("system_settings_title")
-                            Text("system_settings_description")
-                        } icon: {
-                            Image(.faGear)
-                        }
-                    }
-                }
-                
-//                StateView(state: presenter.state.user) { _ in
-//                    NavigationLink(value: Route.moreMenuCustomize) {
-//                        Label {
-//                            Text("more_panel_customize")
-//                        } icon: {
-//                            Image("fa-table-list")
-//                        }
-//                    }
-//                }
-            }
-
-            Section {
-                StateView(state: presenter.state.user) { _ in
-                    NavigationLink(value: Route.localFilter) {
-                        Label {
-                            Text("local_filter_title")
-                            Text("local_filter_description")
-                        } icon: {
-                            Image("fa-filter")
-                        }
-                    }
-                    NavigationLink(value: Route.localHostory) {
-                        Label {
-                            Text("local_history_title")
-                            Text("local_history_description")
-                        } icon: {
-                            Image("fa-clock-rotate-left")
-                        }
-                    }
-                }
-                NavigationLink(value: Route.rssManagement) {
-                    Label {
-                        Text("settings_rss_management_title")
-                        Text("settings_rss_management_description")
-                    } icon: {
-                        Image("fa-square-rss")
-                    }
-                }
-                NavigationLink(value: Route.storage) {
-                    Label {
-                        Text("storage_title")
-                        Text("storage_description")
-                    } icon: {
-                        Image("fa-database")
-                    }
-                }
-            }
-
-            Section {
-                NavigationLink(value: Route.aiConfig) {
-                    Label {
-                        Text("ai_config_title")
-                        Text("ai_config_description")
-                    } icon: {
-                        Image("fa-robot")
-                    }
-
-                }
-            }
-
-            Section {
-                NavigationLink(value: Route.about) {
-                    Label {
-                        Text("about_title")
-                        Text("about_description")
-                    } icon: {
-                        Image("fa-circle-info")
+            .onReceive(NotificationCenter.default.publisher(for: .scrollToTop)) { notification in
+                let targetTab = notification.userInfo?["tab"] as? String
+                if isActive && (targetTab == nil || targetTab == tabKeyEnv) {
+                    withAnimation {
+                        proxy.scrollTo("top", anchor: .top)
                     }
                 }
             }


### PR DESCRIPTION
Closes #1768 

This PR replaces the static ZStack based timeline display with a TabView using the .page style in HomeTimelineScreen and ProfileScreen.

Changes:
   - `HomeTimelineScreen.swift`: Hosted timelines in a TabView to allow horizontal swiping between the "Mixed" timeline and individual account timelines, matching the Android
     HorizontalPager behavior.
   - `ProfileScreen.swift`: Enabled swipe navigation between profile tabs (Timeline, Replies, Media).
   - Navigation Consistency: Ensured the selected tab index remains synchronized with the swipe gestures.


  Validation:
   - Verified manually in the iOS simulator (iPhone 17 Pro).
