### PR TITLE
[bugfix] Fix timeline GIF rendering on iOS/Desktop by enabling Coil GIF decoding

### DIFF
--- a/compose-ui/build.gradle.kts
+++ b/compose-ui/build.gradle.kts
@@ -49,6 +49,7 @@ kotlin {
                 implementation(compose("org.jetbrains.compose.components:components-resources"))
                 implementation(libs.composeIcons.fontAwesome)
                 implementation(libs.coil3.compose)
+                implementation(libs.coil3.gif)
                 implementation(libs.coil3.ktor3)
                 implementation(libs.coil3.network)
                 implementation(libs.compose.placeholder)

--- a/compose-ui/src/iosMain/kotlin/dev/dimension/flare/ui/controllers/ComposeUIHelper.kt
+++ b/compose-ui/src/iosMain/kotlin/dev/dimension/flare/ui/controllers/ComposeUIHelper.kt
@@ -3,6 +3,7 @@ package dev.dimension.flare.ui.controllers
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
 import coil3.annotation.ExperimentalCoilApi
+import coil3.gif.GifDecoder
 import coil3.network.ktor3.KtorNetworkFetcherFactory
 import coil3.request.crossfade
 import dev.dimension.flare.common.InAppNotification
@@ -51,6 +52,7 @@ public object ComposeUIHelper {
             ImageLoader
                 .Builder(context)
                 .components {
+                    add(GifDecoder.Factory())
                     add(
                         KtorNetworkFetcherFactory(
                             httpClient =

--- a/desktopApp/src/main/kotlin/dev/dimension/flare/Main.kt
+++ b/desktopApp/src/main/kotlin/dev/dimension/flare/Main.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
 import coil3.ImageLoader
 import coil3.annotation.ExperimentalCoilApi
+import coil3.gif.GifDecoder
 import coil3.compose.setSingletonImageLoaderFactory
 import coil3.network.ktor3.KtorNetworkFetcherFactory
 import coil3.request.crossfade
@@ -85,6 +86,7 @@ fun main(args: Array<String>) {
             ImageLoader
                 .Builder(context)
                 .components {
+                    add(GifDecoder.Factory())
                     add(
                         KtorNetworkFetcherFactory(
                             httpClient =


### PR DESCRIPTION
在 iOS 端中，timeline 上点开 gif 图片只能查看首帧。

我这没调试条件，先用 codex 糊一版，不 OK 的话我们再看看怎么修。