### PR TITLE
fix: handle TweetWithVisibilityResults in TimelineAddToModule

### DIFF
--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/mapper/XQT.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/mapper/XQT.kt
@@ -203,23 +203,24 @@ internal fun List<InstructionUnion>.tweets(includePin: Boolean = true): List<XQT
 
             is TimelineAddToModule -> {
                 union.moduleItems.mapNotNull {
-                    if (it.item.itemContent is TimelineTweet &&
-                        it.item.itemContent.tweetResults.result is Tweet
-                    ) {
-                        TimelineAddEntry(
-                            content =
-                                TimelineTimelineModule(
-                                    items =
-                                        listOf(
-                                            it,
-                                        ),
-                                ),
-                            entryId = it.entryId,
-                            sortIndex = it.item.itemContent.tweetResults.result.restId,
-                        )
-                    } else {
-                        null
+                    val itemContent = it.item.itemContent
+                    if (itemContent !is TimelineTweet) {
+                        return@mapNotNull null
                     }
+                    val sortIndex =
+                        when (val result = itemContent.tweetResults.result) {
+                            is Tweet -> result.restId
+                            is TweetWithVisibilityResults -> result.tweet.restId
+                            else -> return@mapNotNull null
+                        }
+                    TimelineAddEntry(
+                        content =
+                            TimelineTimelineModule(
+                                items = listOf(it),
+                            ),
+                        entryId = it.entryId,
+                        sortIndex = sortIndex,
+                    )
                 }
             }
 


### PR DESCRIPTION
UserMedia paging responses wrap items in TimelineAddToModule and the tweets are typed TweetWithVisibilityResults rather than Tweet. The previous filter only accepted Tweet, dropping every paged item and causing the UserMedia list to stop loading more.