### PR TITLE
fix: stop profile location from flickering on repeated upserts

### DIFF
--- a/shared/src/commonMain/kotlin/dev/dimension/flare/ui/model/UiProfile.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/ui/model/UiProfile.kt
@@ -11,6 +11,7 @@ import dev.dimension.flare.ui.render.UiRichText
 import dev.dimension.flare.ui.render.toUiPlainText
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
@@ -68,7 +69,7 @@ public data class UiProfile internal constructor(
             sourceLanguages = if (sourceLanguages.isEmpty()) existing.sourceLanguages else sourceLanguages,
             matrices = matrices.mergeWith(existing.matrices),
             mark = (existing.mark + mark).distinct().toPersistentList(),
-            bottomContent = bottomContent ?: existing.bottomContent,
+            bottomContent = mergeBottomContent(bottomContent, existing.bottomContent),
         )
 
     private fun isNostrFallbackHandle(): Boolean =
@@ -164,6 +165,33 @@ public fun createSampleUser(): UiProfile =
         mark = persistentListOf(),
         bottomContent = null,
     )
+
+// Embedded user objects in timeline responses sometimes omit fields like
+// `location` that are present in dedicated profile responses. Falling back to
+// `new ?: existing` would let a slim payload erase richer cached data and make
+// the UI flicker. Merge per-field when both sides expose the same shape.
+private fun mergeBottomContent(
+    new: UiProfile.BottomContent?,
+    existing: UiProfile.BottomContent?,
+): UiProfile.BottomContent? {
+    if (new == null) return existing
+    if (existing == null) return new
+    return when {
+        new is UiProfile.BottomContent.Iconify && existing is UiProfile.BottomContent.Iconify -> {
+            UiProfile.BottomContent.Iconify(
+                items = (existing.items + new.items).toPersistentMap(),
+            )
+        }
+
+        new is UiProfile.BottomContent.Fields && existing is UiProfile.BottomContent.Fields -> {
+            UiProfile.BottomContent.Fields(
+                fields = (existing.fields + new.fields).toPersistentMap(),
+            )
+        }
+
+        else -> new
+    }
+}
 
 private fun UiProfile.Matrices.mergeWith(existing: UiProfile.Matrices): UiProfile.Matrices =
     UiProfile.Matrices(


### PR DESCRIPTION
## Summary
- X timeline responses embed user objects whose `legacy.location` is sometimes null even though `legacy.url` is present, producing a `BottomContent.Iconify` with only a Url entry.
- `UiProfile.mergeWith` previously replaced `bottomContent` wholesale (`new ?: existing`), so the slim payload wiped the cached Location and the profile UI flickered as different responses arrived.
- Merge `BottomContent` per-field when both sides expose the same shape, so keys missing from the new payload fall back to the existing cache entry.

## Test plan
- [ ] Open an X user profile whose location is set; navigate around / scroll the timeline and confirm the location no longer disappears and reappears.