### PR TITLE
fix: stabilize flaky pre-translation and list handler tests

### DIFF
--- a/shared/src/commonTest/kotlin/dev/dimension/flare/data/datasource/microblog/MixedRemoteMediatorTest.kt
+++ b/shared/src/commonTest/kotlin/dev/dimension/flare/data/datasource/microblog/MixedRemoteMediatorTest.kt
@@ -842,7 +842,7 @@ class MixedRemoteMediatorTest : RobolectricTest() {
     @OptIn(ExperimentalPagingApi::class)
     @Test
     fun homeTimelineAcceptsAiSkippedTranslationResult() =
-        runTest {
+        runBlocking {
             val appDataStore = AppDataStore(pathProducer)
             appDataStore.appSettingsStore.updateData {
                 it.copy(
@@ -854,7 +854,7 @@ class MixedRemoteMediatorTest : RobolectricTest() {
                         ),
                 )
             }
-            val scope = CoroutineScope(Dispatchers.Unconfined + Job())
+            val scope = CoroutineScope(Dispatchers.Unconfined + SupervisorJob())
             val preTranslationService: PreTranslationService =
                 OnlinePreTranslationService(
                     database = db,
@@ -863,69 +863,69 @@ class MixedRemoteMediatorTest : RobolectricTest() {
                     coroutineScope = scope,
                 )
             try {
-            val accountKey = MicroBlogKey(id = "account-ai-skipped", host = "test.social")
-            val post =
-                createPost(
-                    accountType = AccountType.Specific(accountKey),
-                    user = profile(MicroBlogKey("user-ai-skipped", "test.social"), "User"),
-                    statusKey = MicroBlogKey("status-ai-skipped", "test.social"),
-                    text = "already target language",
-                )
-            val loader =
-                FakeLoader("home") { request ->
-                    when (request) {
-                        PagingRequest.Refresh -> {
-                            PagingResult(
-                                data = listOf(post),
-                                nextKey = null,
-                            )
-                        }
+                val accountKey = MicroBlogKey(id = "account-ai-skipped", host = "test.social")
+                val post =
+                    createPost(
+                        accountType = AccountType.Specific(accountKey),
+                        user = profile(MicroBlogKey("user-ai-skipped", "test.social"), "User"),
+                        statusKey = MicroBlogKey("status-ai-skipped", "test.social"),
+                        text = "already target language",
+                    )
+                val loader =
+                    FakeLoader("home") { request ->
+                        when (request) {
+                            PagingRequest.Refresh -> {
+                                PagingResult(
+                                    data = listOf(post),
+                                    nextKey = null,
+                                )
+                            }
 
-                        is PagingRequest.Append -> {
-                            error("No append expected")
-                        }
+                            is PagingRequest.Append -> {
+                                error("No append expected")
+                            }
 
-                        is PagingRequest.Prepend -> {
-                            error("No prepend expected")
+                            is PagingRequest.Prepend -> {
+                                error("No prepend expected")
+                            }
                         }
                     }
-                }
-            val mediator =
-                TimelineRemoteMediator(
-                    loader = loader,
-                    database = db,
-                    allowLongText = false,
-                    preTranslationService = preTranslationService,
-                )
+                val mediator =
+                    TimelineRemoteMediator(
+                        loader = loader,
+                        database = db,
+                        allowLongText = false,
+                        preTranslationService = preTranslationService,
+                    )
 
-            val mediatorResult =
-                mediator.load(
-                    loadType = LoadType.REFRESH,
-                    state =
-                        PagingState(
-                            pages = emptyList(),
-                            anchorPosition = null,
-                            config = PagingConfig(pageSize = 20),
-                            leadingPlaceholderCount = 0,
-                        ),
-                )
-            assertTrue(mediatorResult is androidx.paging.RemoteMediator.MediatorResult.Success)
+                val mediatorResult =
+                    mediator.load(
+                        loadType = LoadType.REFRESH,
+                        state =
+                            PagingState(
+                                pages = emptyList(),
+                                anchorPosition = null,
+                                config = PagingConfig(pageSize = 20),
+                                leadingPlaceholderCount = 0,
+                            )
+                    )
+                assertTrue(mediatorResult is androidx.paging.RemoteMediator.MediatorResult.Success)
 
-            val savedStatus = db.statusDao().get(post.statusKey, AccountType.Specific(accountKey)).first()
-            assertNotNull(savedStatus)
-            val translation =
-                withTimeout(5_000) {
-                    db
-                        .translationDao()
-                        .find(
-                            entityType = TranslationEntityType.Status,
-                            entityKey = savedStatus.id,
-                            targetLanguage = Locale.language,
-                        ).filterNotNull()
-                        .first { it.status == TranslationStatus.Skipped }
-                }
-            assertEquals(TranslationStatus.Skipped, translation.status)
-            assertEquals("same_language", translation.statusReason)
+                val savedStatus = db.statusDao().get(post.statusKey, AccountType.Specific(accountKey)).first()
+                assertNotNull(savedStatus)
+                val translation =
+                    withTimeout(5_000) {
+                        db
+                            .translationDao()
+                            .find(
+                                entityType = TranslationEntityType.Status,
+                                entityKey = savedStatus.id,
+                                targetLanguage = Locale.language,
+                            ).filterNotNull()
+                            .first { it.status == TranslationStatus.Skipped }
+                    }
+                assertEquals(TranslationStatus.Skipped, translation.status)
+                assertEquals("same_language", translation.statusReason)
             } finally {
                 scope.coroutineContext[Job]?.cancelAndJoin()
             }

--- a/shared/src/commonTest/kotlin/dev/dimension/flare/data/datasource/microblog/MixedRemoteMediatorTest.kt
+++ b/shared/src/commonTest/kotlin/dev/dimension/flare/data/datasource/microblog/MixedRemoteMediatorTest.kt
@@ -854,13 +854,15 @@ class MixedRemoteMediatorTest : RobolectricTest() {
                         ),
                 )
             }
+            val scope = CoroutineScope(Dispatchers.Unconfined + Job())
             val preTranslationService: PreTranslationService =
                 OnlinePreTranslationService(
                     database = db,
                     appDataStore = appDataStore,
                     aiCompletionService = AiCompletionService(OpenAIService(), SkippingOnDeviceAI()),
-                    coroutineScope = CoroutineScope(Dispatchers.Unconfined),
+                    coroutineScope = scope,
                 )
+            try {
             val accountKey = MicroBlogKey(id = "account-ai-skipped", host = "test.social")
             val post =
                 createPost(
@@ -912,16 +914,21 @@ class MixedRemoteMediatorTest : RobolectricTest() {
             val savedStatus = db.statusDao().get(post.statusKey, AccountType.Specific(accountKey)).first()
             assertNotNull(savedStatus)
             val translation =
-                db
-                    .translationDao()
-                    .find(
-                        entityType = TranslationEntityType.Status,
-                        entityKey = savedStatus.id,
-                        targetLanguage = Locale.language,
-                    ).filterNotNull()
-                    .first()
+                withTimeout(5_000) {
+                    db
+                        .translationDao()
+                        .find(
+                            entityType = TranslationEntityType.Status,
+                            entityKey = savedStatus.id,
+                            targetLanguage = Locale.language,
+                        ).filterNotNull()
+                        .first { it.status == TranslationStatus.Skipped }
+                }
             assertEquals(TranslationStatus.Skipped, translation.status)
             assertEquals("same_language", translation.statusReason)
+            } finally {
+                scope.coroutineContext[Job]?.cancelAndJoin()
+            }
         }
 
     @OptIn(ExperimentalPagingApi::class)

--- a/shared/src/commonTest/kotlin/dev/dimension/flare/data/datasource/microblog/handler/ListHandlerTest.kt
+++ b/shared/src/commonTest/kotlin/dev/dimension/flare/data/datasource/microblog/handler/ListHandlerTest.kt
@@ -70,8 +70,11 @@ class ListHandlerTest : RobolectricTest() {
 
     @AfterTest
     fun tearDown() {
-        db.close()
-        stopKoin()
+        try {
+            db.close()
+        } finally {
+            stopKoin()
+        }
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/dev/dimension/flare/data/network/bluesky/BlueskyAuthPluginTest.kt
+++ b/shared/src/commonTest/kotlin/dev/dimension/flare/data/network/bluesky/BlueskyAuthPluginTest.kt
@@ -16,10 +16,13 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import sh.christian.ozone.BlueskyJson
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -144,7 +147,9 @@ class BlueskyAuthPluginTest {
                                             // Park the first request inside the mock until the
                                             // second one also arrives, so both observe an expired
                                             // token before either of them gets to refresh.
-                                            bothExpiredReachedMock.await()
+                                            withTimeout(5_000) {
+                                                bothExpiredReachedMock.await()
+                                            }
                                         }
 
                                         2 -> {
@@ -177,22 +182,18 @@ class BlueskyAuthPluginTest {
             val results =
                 supervisorScope {
                     val requestOne =
-                        async {
+                        async(start = CoroutineStart.UNDISPATCHED) {
                             client.get("https://bsky.social/xrpc/app.bsky.feed.getTimeline").bodyAsText()
                         }
                     val requestTwo =
-                        async {
+                        async(start = CoroutineStart.UNDISPATCHED) {
                             client.get("https://bsky.social/xrpc/app.bsky.actor.getProfile").bodyAsText()
                         }
-                    listOf(
-                        runCatching { requestOne.await() },
-                        runCatching { requestTwo.await() },
-                    )
+                    runCatching { awaitAll(requestOne, requestTwo) }
                 }
 
             assertEquals(1, refreshCalls)
-            assertEquals(2, results.count { it.isSuccess })
-            assertEquals(listOf("""{"ok":true}""", """{"ok":true}"""), results.map { it.getOrThrow() })
+            assertEquals(listOf("""{"ok":true}""", """{"ok":true}"""), results.getOrThrow())
             assertEquals("access-new", credentialFlow.value.accessToken)
             assertEquals("refresh-new", credentialFlow.value.refreshToken)
         }

--- a/shared/src/commonTest/kotlin/dev/dimension/flare/data/network/bluesky/BlueskyAuthPluginTest.kt
+++ b/shared/src/commonTest/kotlin/dev/dimension/flare/data/network/bluesky/BlueskyAuthPluginTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import sh.christian.ozone.BlueskyJson
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -102,7 +103,8 @@ class BlueskyAuthPluginTest {
                         refreshToken = "refresh-old",
                     ),
                 )
-            val secondExpiredResponseStarted = CompletableDeferred<Unit>()
+            val firstExpiredReachedMock = CompletableDeferred<Unit>()
+            val secondExpiredReachedMock = CompletableDeferred<Unit>()
             var expiredCalls = 0
             var refreshCalls = 0
 
@@ -139,11 +141,21 @@ class BlueskyAuthPluginTest {
                         else -> {
                             when (authorization) {
                                 "Bearer access-old" -> {
-                                    expiredCalls += 1
-                                    if (expiredCalls == 1) {
-                                        secondExpiredResponseStarted.await()
-                                    } else if (expiredCalls == 2) {
-                                        secondExpiredResponseStarted.complete(Unit)
+                                    val callIndex = ++expiredCalls
+                                    when (callIndex) {
+                                        1 -> {
+                                            firstExpiredReachedMock.complete(Unit)
+                                            // Wait until the second concurrent request also
+                                            // reaches the mock so both observe an expired token
+                                            // before either gets to refresh.
+                                            secondExpiredReachedMock.await()
+                                        }
+
+                                        2 -> {
+                                            secondExpiredReachedMock.complete(Unit)
+                                        }
+
+                                        else -> error("Unexpected expired call count: $callIndex")
                                     }
                                     jsonResponse(
                                         HttpStatusCode.Unauthorized,
@@ -172,6 +184,10 @@ class BlueskyAuthPluginTest {
                         async(start = CoroutineStart.UNDISPATCHED) {
                             client.get("https://bsky.social/xrpc/app.bsky.feed.getTimeline").bodyAsText()
                         }
+                    // Make sure request one is parked inside the mock before we launch
+                    // request two, so the relative ordering of the two mock invocations is
+                    // fully deterministic regardless of the test scheduler.
+                    withTimeout(5_000) { firstExpiredReachedMock.await() }
                     val requestTwo =
                         async(start = CoroutineStart.UNDISPATCHED) {
                             client.get("https://bsky.social/xrpc/app.bsky.actor.getProfile").bodyAsText()

--- a/shared/src/commonTest/kotlin/dev/dimension/flare/data/network/bluesky/BlueskyAuthPluginTest.kt
+++ b/shared/src/commonTest/kotlin/dev/dimension/flare/data/network/bluesky/BlueskyAuthPluginTest.kt
@@ -16,12 +16,10 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.withTimeout
 import sh.christian.ozone.BlueskyJson
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -103,8 +101,7 @@ class BlueskyAuthPluginTest {
                         refreshToken = "refresh-old",
                     ),
                 )
-            val firstExpiredReachedMock = CompletableDeferred<Unit>()
-            val secondExpiredReachedMock = CompletableDeferred<Unit>()
+            val bothExpiredReachedMock = CompletableDeferred<Unit>()
             var expiredCalls = 0
             var refreshCalls = 0
 
@@ -144,15 +141,14 @@ class BlueskyAuthPluginTest {
                                     val callIndex = ++expiredCalls
                                     when (callIndex) {
                                         1 -> {
-                                            firstExpiredReachedMock.complete(Unit)
-                                            // Wait until the second concurrent request also
-                                            // reaches the mock so both observe an expired token
-                                            // before either gets to refresh.
-                                            secondExpiredReachedMock.await()
+                                            // Park the first request inside the mock until the
+                                            // second one also arrives, so both observe an expired
+                                            // token before either of them gets to refresh.
+                                            bothExpiredReachedMock.await()
                                         }
 
                                         2 -> {
-                                            secondExpiredReachedMock.complete(Unit)
+                                            bothExpiredReachedMock.complete(Unit)
                                         }
 
                                         else -> error("Unexpected expired call count: $callIndex")
@@ -181,15 +177,11 @@ class BlueskyAuthPluginTest {
             val results =
                 supervisorScope {
                     val requestOne =
-                        async(start = CoroutineStart.UNDISPATCHED) {
+                        async {
                             client.get("https://bsky.social/xrpc/app.bsky.feed.getTimeline").bodyAsText()
                         }
-                    // Make sure request one is parked inside the mock before we launch
-                    // request two, so the relative ordering of the two mock invocations is
-                    // fully deterministic regardless of the test scheduler.
-                    withTimeout(5_000) { firstExpiredReachedMock.await() }
                     val requestTwo =
-                        async(start = CoroutineStart.UNDISPATCHED) {
+                        async {
                             client.get("https://bsky.social/xrpc/app.bsky.actor.getProfile").bodyAsText()
                         }
                     listOf(


### PR DESCRIPTION
## Summary
- `MixedRemoteMediatorTest.homeTimelineAcceptsAiSkippedTranslationResult` was asserting on the first emission from the translation flow, but `enqueueStatuses` runs in a fire-and-forget coroutine that writes `Pending` / `Translating` rows before reaching `Skipped`. On a slower CI scheduler the test caught an intermediate state and failed. The test now uses `withTimeout(5_000) { ... .first { it.status == TranslationStatus.Skipped } }` and cancels its `coroutineScope` in a `finally` block (matching neighbouring tests) so leftover work cannot leak between tests.
- `ListHandlerTest.tearDown` now closes the database inside `try/finally` so `stopKoin()` always runs even if `db.close()` throws. This prevents leftover Koin state from cascading into a `UncaughtExceptionsBeforeTest` failure on the next test (e.g. `withDatabaseUpdatesContent`).

## Test plan
- [x] `./gradlew :shared:jvmTest --tests dev.dimension.flare.data.datasource.microblog.MixedRemoteMediatorTest.homeTimelineAcceptsAiSkippedTranslationResult`
- [x] `./gradlew :shared:jvmTest --tests dev.dimension.flare.data.datasource.microblog.handler.ListHandlerTest`
- [x] `./gradlew :shared:jvmTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)