### PR TITLE
fix(login): also clear cache / history / form data on VVO and XQT login

### DIFF
--- a/app/src/main/java/dev/dimension/flare/ui/screen/serviceselect/VVOLoginScreen.kt
+++ b/app/src/main/java/dev/dimension/flare/ui/screen/serviceselect/VVOLoginScreen.kt
@@ -59,8 +59,13 @@ internal fun VVOLoginScreen(toHome: () -> Unit) {
                     .padding(it)
                     .fillMaxSize(),
             onCreated = {
-                // clea all cookies
+                // clear all cookies, cache and history so the login WebView
+                // starts from a clean slate even if a previous account left
+                // state behind
                 CookieManager.getInstance().removeAllCookies(null)
+                it.clearCache(true)
+                it.clearHistory()
+                it.clearFormData()
                 with(it.settings) {
                     javaScriptEnabled = true
 //                    domStorageEnabled = true

--- a/app/src/main/java/dev/dimension/flare/ui/screen/serviceselect/XQTLoginScreen.kt
+++ b/app/src/main/java/dev/dimension/flare/ui/screen/serviceselect/XQTLoginScreen.kt
@@ -70,9 +70,14 @@ internal fun XQTLoginScreen(toHome: () -> Unit) {
                     .padding(it)
                     .fillMaxSize(),
             onCreated = {
-                // clea all cookies
+                // clear all cookies, web storage, cache and history so the
+                // login WebView starts from a clean slate even if a previous
+                // account left state behind
                 WebStorage.getInstance().deleteAllData()
                 CookieManager.getInstance().removeAllCookies(null)
+                it.clearCache(true)
+                it.clearHistory()
+                it.clearFormData()
                 with(it.settings) {
                     userAgentString = userAgent.toString()
                     javaScriptEnabled = true


### PR DESCRIPTION
Closes #2154.

`VVOLoginScreen` and `XQTLoginScreen` both want a fresh WebView for each sign-in attempt, but the cleanup in `onCreated` only handles cookies (and, for XQT, web storage). The WebView's disk cache, navigation history and saved form data carry over from any previous login session that ran in the same process.

Add the standard cleanup calls inside both `onCreated` lambdas:

```kotlin
CookieManager.getInstance().removeAllCookies(null)
it.clearCache(true)
it.clearHistory()
it.clearFormData()
```

For `XQTLoginScreen` this keeps the existing `WebStorage.getInstance().deleteAllData()` call too.

After this change a fresh launch of the login screen really does start from zero, even if a previous VVO / X account left state behind in the same install.
