### PR TITLE
VVO/XQT login: clear WebView cache, history and form data on create

### DIFF
--- a/app/src/main/java/dev/dimension/flare/ui/screen/serviceselect/VVOLoginScreen.kt
+++ b/app/src/main/java/dev/dimension/flare/ui/screen/serviceselect/VVOLoginScreen.kt
@@ -59,8 +59,12 @@ internal fun VVOLoginScreen(toHome: () -> Unit) {
                     .padding(it)
                     .fillMaxSize(),
             onCreated = {
-                // clea all cookies
+                // clea all cookies + WebView-side caches/history/form data so a
+                // previous Weibo login session cannot leak into this one
                 CookieManager.getInstance().removeAllCookies(null)
+                it.clearCache(true)
+                it.clearHistory()
+                it.clearFormData()
                 with(it.settings) {
                     javaScriptEnabled = true
 //                    domStorageEnabled = true

--- a/app/src/main/java/dev/dimension/flare/ui/screen/serviceselect/XQTLoginScreen.kt
+++ b/app/src/main/java/dev/dimension/flare/ui/screen/serviceselect/XQTLoginScreen.kt
@@ -70,9 +70,15 @@ internal fun XQTLoginScreen(toHome: () -> Unit) {
                     .padding(it)
                     .fillMaxSize(),
             onCreated = {
-                // clea all cookies
+                // clea all cookies + WebView-side caches/history/form data so a
+                // previous X (Twitter) session cannot survive a re-login attempt.
+                // The cacheMode below is LOAD_CACHE_ELSE_NETWORK, which makes
+                // skipping this step especially sticky.
                 WebStorage.getInstance().deleteAllData()
                 CookieManager.getInstance().removeAllCookies(null)
+                it.clearCache(true)
+                it.clearHistory()
+                it.clearFormData()
                 with(it.settings) {
                     userAgentString = userAgent.toString()
                     javaScriptEnabled = true


### PR DESCRIPTION
Closes #2161.

Both `VVOLoginScreen` and `XQTLoginScreen` already null out cookies (XQT also wipes `WebStorage`) inside their `WebView` `onCreated` block, but neither clears the WebView instance's own state. That means cached HTML/CSS/JS from a previous login attempt and any form data the WebView remembered can leak into the next login flow.

XQT is particularly sticky because it sets:

```kotlin
cacheMode = WebSettings.LOAD_CACHE_ELSE_NETWORK
```

The WebView is told to prefer the cached copy of the X login page over a fresh network fetch, so a stale login HTML captured during a previous session can be replayed even after cookies have been removed. Adding the cache wipe is the canonical pairing for "I just removed cookies, please do not serve me the previous user's page" (the [WebView docs](https://developer.android.com/reference/android/webkit/WebView#clearCache(boolean)) call this out explicitly).

This PR adds three calls inside each `onCreated` block, immediately after the cookie removal that is already there:

```kotlin
it.clearCache(true)
it.clearHistory()
it.clearFormData()
```

Two short comments are also added in both files to spell out why the trio sits right next to the existing cookie wipe, since the existing `// clea all cookies` comment is the only hint future readers get.

No new permission, no new dependency, no behaviour change for a first-time login.