### PR TITLE
move bookmark action button to the bottom of the post.

### DIFF
--- a/social/xqt/src/commonMain/kotlin/dev/dimension/flare/ui/model/mapper/XQT.kt
+++ b/social/xqt/src/commonMain/kotlin/dev/dimension/flare/ui/model/mapper/XQT.kt
@@ -707,6 +707,12 @@ internal fun Tweet.renderStatus(
                     count = legacy?.favoriteCount?.toLong() ?: 0,
                     accountKey = accountKey,
                 ),
+                ActionMenu.xqtBookmark(
+                    statusKey = statusKey,
+                    bookmarked = legacy?.bookmarked == true,
+                    count = legacy?.bookmarkCount?.toLong() ?: 0,
+                    accountKey = accountKey,
+                ),
                 ActionMenu.Group(
                     displayItem =
                         ActionMenu.Item(
@@ -715,14 +721,6 @@ internal fun Tweet.renderStatus(
                         ),
                     actions =
                         buildList {
-                            add(
-                                ActionMenu.xqtBookmark(
-                                    statusKey = statusKey,
-                                    bookmarked = legacy?.bookmarked == true,
-                                    count = legacy?.bookmarkCount?.toLong() ?: 0,
-                                    accountKey = accountKey,
-                                ),
-                            )
                             add(
                                 ActionMenu.Item(
                                     icon = UiIcon.Share,


### PR DESCRIPTION
the bookmark action button is very commonly used, it's better to move it from the menu to the button bar of the post.