### PR TITLE
Fix Pixiv original image quality

### DIFF
--- a/social/pixiv/src/commonMain/kotlin/dev/dimension/flare/data/datasource/pixiv/PixivMapper.kt
+++ b/social/pixiv/src/commonMain/kotlin/dev/dimension/flare/data/datasource/pixiv/PixivMapper.kt
@@ -258,7 +258,7 @@ private fun PixivIllust.renderContent(): String =
         }
     }
 
-private fun PixivIllust.toUiMedia(): List<UiMedia> {
+internal fun PixivIllust.toUiMedia(): List<UiMedia> {
     val headers = persistentMapOf("Referer" to PIXIV_IMAGE_REFERER)
     return if (metaPages.isNotEmpty()) {
         metaPages.mapNotNull { page ->
@@ -276,6 +276,7 @@ private fun PixivIllust.toUiMedia(): List<UiMedia> {
                 height = height.toFloat(),
                 sensitive = xRestrict > 0 || sanityLevel >= 6,
                 headers = headers,
+                preferredOriginalUrl = metaSinglePage?.originalImageUrl,
             )?.let(::listOf)
             .orEmpty()
     }
@@ -286,8 +287,9 @@ private fun dev.dimension.flare.data.network.pixiv.model.PixivImageUrls.toUiImag
     height: Float,
     sensitive: Boolean,
     headers: kotlinx.collections.immutable.ImmutableMap<String, String>,
+    preferredOriginalUrl: String? = null,
 ): UiMedia.Image? {
-    val url = original ?: large ?: medium ?: squareMedium ?: return null
+    val url = preferredOriginalUrl?.takeIf { it.isNotBlank() } ?: original ?: large ?: medium ?: squareMedium ?: return null
     return UiMedia.Image(
         url = url,
         previewUrl = medium ?: squareMedium ?: url,

--- a/social/pixiv/src/commonTest/kotlin/dev/dimension/flare/data/datasource/pixiv/PixivMapperTest.kt
+++ b/social/pixiv/src/commonTest/kotlin/dev/dimension/flare/data/datasource/pixiv/PixivMapperTest.kt
@@ -1,0 +1,88 @@
+package dev.dimension.flare.data.datasource.pixiv
+
+import dev.dimension.flare.data.network.pixiv.model.PixivIllust
+import dev.dimension.flare.data.network.pixiv.model.PixivImageUrls
+import dev.dimension.flare.data.network.pixiv.model.PixivMetaPage
+import dev.dimension.flare.data.network.pixiv.model.PixivMetaSinglePage
+import dev.dimension.flare.data.network.pixiv.model.PixivUser
+import dev.dimension.flare.ui.model.UiMedia
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class PixivMapperTest {
+    @Test
+    fun singlePageIllustUsesMetaSinglePageOriginalImageUrl() {
+        val post =
+            pixivIllust(
+                imageUrls =
+                    PixivImageUrls(
+                        squareMedium = "https://example.com/square.jpg",
+                        medium = "https://example.com/medium.jpg",
+                        large = "https://example.com/large.jpg",
+                    ),
+                metaSinglePage =
+                    PixivMetaSinglePage(
+                        originalImageUrl = "https://example.com/original.png",
+                    ),
+            ).toUiMedia()
+
+        val image = assertIs<UiMedia.Image>(post.single())
+        assertEquals("https://example.com/original.png", image.url)
+        assertEquals("https://example.com/medium.jpg", image.previewUrl)
+    }
+
+    @Test
+    fun multiPageIllustUsesPageImageUrls() {
+        val post =
+            pixivIllust(
+                imageUrls =
+                    PixivImageUrls(
+                        medium = "https://example.com/cover-medium.jpg",
+                        large = "https://example.com/cover-large.jpg",
+                    ),
+                metaSinglePage =
+                    PixivMetaSinglePage(
+                        originalImageUrl = "https://example.com/cover-original.png",
+                    ),
+                metaPages =
+                    listOf(
+                        PixivMetaPage(
+                            imageUrls =
+                                PixivImageUrls(
+                                    medium = "https://example.com/page-0-medium.jpg",
+                                    large = "https://example.com/page-0-large.jpg",
+                                    original = "https://example.com/page-0-original.png",
+                                ),
+                        ),
+                    ),
+            ).toUiMedia()
+
+        val image = assertIs<UiMedia.Image>(post.single())
+        assertEquals("https://example.com/page-0-original.png", image.url)
+        assertEquals("https://example.com/page-0-medium.jpg", image.previewUrl)
+    }
+
+    private fun pixivIllust(
+        imageUrls: PixivImageUrls,
+        metaSinglePage: PixivMetaSinglePage? = null,
+        metaPages: List<PixivMetaPage> = emptyList(),
+    ): PixivIllust =
+        PixivIllust(
+            id = 146347478,
+            title = "As if in a dream",
+            type = "illust",
+            imageUrls = imageUrls,
+            user =
+                PixivUser(
+                    id = 21714218,
+                    name = "Hyde",
+                    account = "hidetohyde",
+                ),
+            createDate = "2026-06-22T22:09:00+00:00",
+            width = 4000,
+            height = 3000,
+            metaSinglePage = metaSinglePage,
+            metaPages = metaPages,
+        )
+}


### PR DESCRIPTION
## Summary

- Use `meta_single_page.original_image_url` as the full-size URL for single-page Pixiv illustrations.
- Keep medium images as timeline previews so feeds do not eagerly load original images.
- Add Pixiv mapper tests for single-page original URLs and multi-page image URL behavior.

## Root Cause

Pixiv single-page illustration originals are returned in `meta_single_page.original_image_url`, not in `image_urls.original` for the affected API response. Flare only mapped `image_urls`, so image viewing and saving could fall back to the lower-resolution `large` asset.

## Validation

- `./gradlew :social:pixiv:jvmTest`
- `./gradlew :social:pixiv:runKtlintCheckOverCommonMainSourceSet :social:pixiv:runKtlintCheckOverCommonTestSourceSet`

Fixes #2246