### PR TITLE
Fix Pixiv home timeline source

### DIFF
--- a/social/pixiv/src/commonMain/kotlin/dev/dimension/flare/data/datasource/pixiv/PixivTimelineLoaders.kt
+++ b/social/pixiv/src/commonMain/kotlin/dev/dimension/flare/data/datasource/pixiv/PixivTimelineLoaders.kt
@@ -57,10 +57,7 @@ internal class PixivHomeTimelineLoader(
 ) : PixivTimelineLoader(service, accountKey) {
     override val pagingKey: String = "pixiv_home_$accountKey"
 
-    override suspend fun loadFirstPage(pageSize: Int): PixivIllustListResponse =
-        service.recommendedIllusts(
-            includeRankingIllusts = true,
-        )
+    override suspend fun loadFirstPage(pageSize: Int): PixivIllustListResponse = service.followedIllusts()
 }
 
 internal class PixivDiscoverTimelineLoader(


### PR DESCRIPTION
## Summary

- Change the Pixiv Home timeline loader to fetch followed users' illustrations instead of recommended illustrations.
- Keep Discover, Ranking, Bookmark, and the explicit Following timeline behavior unchanged.

## Root Cause

The default Pixiv timeline tab is registered as `CommonTimelineSpecs.home`, which resolves to `PixivDataSource.homeTimeline()`. That loader was using Pixiv's recommended illustrations endpoint, so the default Pixiv tab showed recommendations instead of followed-user updates.

Fixes #2248

## Validation

- `./gradlew :social:pixiv:compileKotlinJvm :social:pixiv:jvmTest`