### PR TITLE
fix pixiv private timelines

### DIFF
--- a/app/src/main/java/dev/dimension/flare/ui/screen/settings/EditTabDialog.kt
+++ b/app/src/main/java/dev/dimension/flare/ui/screen/settings/EditTabDialog.kt
@@ -219,4 +219,6 @@ private val UiStrings.androidStringRes: Int
             UiStrings.Manga -> R.string.manga_title
             UiStrings.FanboxSupported -> R.string.fanbox_supported_title
             UiStrings.FanboxRecommendedCreators -> R.string.fanbox_recommended_creators_title
+            UiStrings.PixivPrivateFollowing -> R.string.pixiv_private_following_title
+            UiStrings.PixivPrivateBookmarks -> R.string.pixiv_private_bookmarks_title
         }

--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -655,6 +655,8 @@
     <string name="pixiv_ranking_week_original_title">Original Ranking</string>
     <string name="pixiv_ranking_week_rookie_title">Rookie Ranking</string>
     <string name="pixiv_ranking_day_manga_title">Manga Ranking</string>
+    <string name="pixiv_private_following_title">Private Following</string>
+    <string name="pixiv_private_bookmarks_title">Private Bookmarks</string>
     <string name="agent_ui_cancel">Cancel</string>
     <string name="agent_ui_confirm_execute">Confirm</string>
     <string name="agent_ui_confirm_save_subscription">Save</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -516,6 +516,8 @@
     <string name="pixiv_ranking_week_original_title">Original Ranking</string>
     <string name="pixiv_ranking_week_rookie_title">Rookie Ranking</string>
     <string name="pixiv_ranking_day_manga_title">Manga Ranking</string>
+    <string name="pixiv_private_following_title">Private Following</string>
+    <string name="pixiv_private_bookmarks_title">Private Bookmarks</string>
 
     <string name="tab_settings_title">Tab settings</string>
 

--- a/appleApp/Shared/FlareAppleCore/Sources/FlareAppleCore/PresentationMappings.swift
+++ b/appleApp/Shared/FlareAppleCore/Sources/FlareAppleCore/PresentationMappings.swift
@@ -110,6 +110,10 @@ public extension UiStrings {
             localizedPresentationString("pixiv_ranking_week_rookie_title", fallback: "Rookie Ranking")
         case .pixivRankingDayManga:
             localizedPresentationString("pixiv_ranking_day_manga_title", fallback: "Manga Ranking")
+        case .pixivPrivateFollowing:
+            localizedPresentationString("pixiv_private_following_title", fallback: "Private Following")
+        case .pixivPrivateBookmarks:
+            localizedPresentationString("pixiv_private_bookmarks_title", fallback: "Private Bookmarks")
         case .illustrations:
             localizedPresentationString("illustrations_title", fallback: "Illustrations")
         case .manga:

--- a/appleApp/Shared/FlareAppleResource/Resources/Localizable.xcstrings
+++ b/appleApp/Shared/FlareAppleResource/Resources/Localizable.xcstrings
@@ -100737,6 +100737,26 @@
         }
       }
     },
+    "pixiv_private_bookmarks_title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Private Bookmarks"
+          }
+        }
+      }
+    },
+    "pixiv_private_following_title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Private Following"
+          }
+        }
+      }
+    },
     "pixiv_ranking_day_female_title" : {
       "comment" : "Title of the ranking of female artists on the pixiv app.",
       "extractionState" : "stale",

--- a/compose-ui/src/commonMain/composeResources/values-en-rUS/strings.xml
+++ b/compose-ui/src/commonMain/composeResources/values-en-rUS/strings.xml
@@ -417,6 +417,8 @@
     <string name="pixiv_ranking_week_original_title">Original Ranking</string>
     <string name="pixiv_ranking_week_rookie_title">Rookie Ranking</string>
     <string name="pixiv_ranking_day_manga_title">Manga Ranking</string>
+    <string name="pixiv_private_following_title">Private Following</string>
+    <string name="pixiv_private_bookmarks_title">Private Bookmarks</string>
     <string name="illustrations_title">Illustrations</string>
     <string name="manga_title">Manga</string>
 </resources>

--- a/compose-ui/src/commonMain/composeResources/values/strings.xml
+++ b/compose-ui/src/commonMain/composeResources/values/strings.xml
@@ -527,6 +527,8 @@
     <string name="pixiv_ranking_week_original_title">Original Ranking</string>
     <string name="pixiv_ranking_week_rookie_title">Rookie Ranking</string>
     <string name="pixiv_ranking_day_manga_title">Manga Ranking</string>
+    <string name="pixiv_private_following_title">Private Following</string>
+    <string name="pixiv_private_bookmarks_title">Private Bookmarks</string>
     <string name="illustrations_title">Illustrations</string>
     <string name="manga_title">Manga</string>
     <string name="fanbox_supported_title">Supported posts</string>

--- a/compose-ui/src/commonMain/kotlin/dev/dimension/flare/ui/component/TabIcon.kt
+++ b/compose-ui/src/commonMain/kotlin/dev/dimension/flare/ui/component/TabIcon.kt
@@ -51,6 +51,8 @@ import dev.dimension.flare.compose.ui.nostr_login_account_hint
 import dev.dimension.flare.compose.ui.nostr_login_amber_button
 import dev.dimension.flare.compose.ui.nostr_login_qr_button
 import dev.dimension.flare.compose.ui.nostr_login_title
+import dev.dimension.flare.compose.ui.pixiv_private_bookmarks_title
+import dev.dimension.flare.compose.ui.pixiv_private_following_title
 import dev.dimension.flare.compose.ui.pixiv_ranking_day_female_title
 import dev.dimension.flare.compose.ui.pixiv_ranking_day_male_title
 import dev.dimension.flare.compose.ui.pixiv_ranking_day_manga_title
@@ -322,4 +324,6 @@ internal val UiStrings.res: StringResource
             UiStrings.Manga -> Res.string.manga_title
             UiStrings.FanboxSupported -> Res.string.fanbox_supported_title
             UiStrings.FanboxRecommendedCreators -> Res.string.fanbox_recommended_creators_title
+            UiStrings.PixivPrivateFollowing -> Res.string.pixiv_private_following_title
+            UiStrings.PixivPrivateBookmarks -> Res.string.pixiv_private_bookmarks_title
         }

--- a/desktopApp/src/main/composeResources/values/strings.xml
+++ b/desktopApp/src/main/composeResources/values/strings.xml
@@ -52,6 +52,8 @@
     <string name="pixiv_ranking_week_original_title">Original Ranking</string>
     <string name="pixiv_ranking_week_rookie_title">Rookie Ranking</string>
     <string name="pixiv_ranking_day_manga_title">Manga Ranking</string>
+    <string name="pixiv_private_following_title">Private Following</string>
+    <string name="pixiv_private_bookmarks_title">Private Bookmarks</string>
 
     <string name="report_title">Report</string>
     <string name="report_description">What's wrong with this post?</string>

--- a/desktopApp/src/main/kotlin/dev/dimension/flare/ui/screen/home/EditTabDialog.kt
+++ b/desktopApp/src/main/kotlin/dev/dimension/flare/ui/screen/home/EditTabDialog.kt
@@ -52,6 +52,8 @@ import dev.dimension.flare.mastodon_tab_public_title
 import dev.dimension.flare.misskey_channel_tab_following
 import dev.dimension.flare.mixed_timeline_title
 import dev.dimension.flare.ok
+import dev.dimension.flare.pixiv_private_bookmarks_title
+import dev.dimension.flare.pixiv_private_following_title
 import dev.dimension.flare.pixiv_ranking_day_female_title
 import dev.dimension.flare.pixiv_ranking_day_male_title
 import dev.dimension.flare.pixiv_ranking_day_manga_title
@@ -267,4 +269,6 @@ private val UiStrings.desktopStringResource: StringResource
             UiStrings.Manga -> Res.string.manga_title
             UiStrings.FanboxSupported -> Res.string.fanbox_supported_title
             UiStrings.FanboxRecommendedCreators -> Res.string.fanbox_recommended_creators_title
+            UiStrings.PixivPrivateFollowing -> Res.string.pixiv_private_following_title
+            UiStrings.PixivPrivateBookmarks -> Res.string.pixiv_private_bookmarks_title
         }

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/ui/model/UiStrings.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/ui/model/UiStrings.kt
@@ -56,6 +56,8 @@ public enum class UiStrings {
     Media,
     FanboxSupported,
     FanboxRecommendedCreators,
+    PixivPrivateFollowing,
+    PixivPrivateBookmarks,
 }
 
 public fun UiStrings.asText(): UiText = UiText.Localized(this)

--- a/social/pixiv/src/commonMain/kotlin/dev/dimension/flare/data/datasource/pixiv/PixivDataSource.kt
+++ b/social/pixiv/src/commonMain/kotlin/dev/dimension/flare/data/datasource/pixiv/PixivDataSource.kt
@@ -27,6 +27,7 @@ import dev.dimension.flare.data.model.tab.ShortcutSpec
 import dev.dimension.flare.data.model.tab.TimelineCandidate
 import dev.dimension.flare.data.model.tab.TimelineSpec
 import dev.dimension.flare.data.network.pixiv.PixivRankingMode
+import dev.dimension.flare.data.network.pixiv.PixivRestrict
 import dev.dimension.flare.data.network.pixiv.PixivService
 import dev.dimension.flare.data.network.pixiv.PixivWorkType
 import dev.dimension.flare.data.platform.CommonTimelineSpecs
@@ -128,7 +129,13 @@ internal class PixivDataSource(
             PixivPlatformSpec.followingTimelineSpec.galleryCandidate(
                 data = TimelineSpec.AccountBasedData(accountKey),
             ),
+            PixivPlatformSpec.privateFollowingTimelineSpec.galleryCandidate(
+                data = TimelineSpec.AccountBasedData(accountKey),
+            ),
             PixivPlatformSpec.bookmarkTimelineSpec.galleryCandidate(
+                data = TimelineSpec.AccountBasedData(accountKey),
+            ),
+            PixivPlatformSpec.privateBookmarkTimelineSpec.galleryCandidate(
                 data = TimelineSpec.AccountBasedData(accountKey),
             ),
             PixivPlatformSpec.rankingWeekTimelineSpec.galleryCandidate(
@@ -190,11 +197,31 @@ internal class PixivDataSource(
                     ),
             ),
             ShortcutSpec(
+                title = UiStrings.PixivPrivateFollowing,
+                icon = UiIcon.Follow,
+                target =
+                    ShortcutSpec.Target.Timeline(
+                        PixivPlatformSpec.privateFollowingTimelineSpec.galleryCandidate(
+                            data = TimelineSpec.AccountBasedData(accountKey),
+                        ),
+                    ),
+            ),
+            ShortcutSpec(
                 title = UiStrings.Bookmark,
                 icon = UiIcon.Bookmark,
                 target =
                     ShortcutSpec.Target.Timeline(
                         PixivPlatformSpec.bookmarkTimelineSpec.galleryCandidate(
+                            data = TimelineSpec.AccountBasedData(accountKey),
+                        ),
+                    ),
+            ),
+            ShortcutSpec(
+                title = UiStrings.PixivPrivateBookmarks,
+                icon = UiIcon.Bookmark,
+                target =
+                    ShortcutSpec.Target.Timeline(
+                        PixivPlatformSpec.privateBookmarkTimelineSpec.galleryCandidate(
                             data = TimelineSpec.AccountBasedData(accountKey),
                         ),
                     ),
@@ -388,17 +415,23 @@ internal class PixivDataSource(
             service = service,
         )
 
-    fun bookmarkTimelineLoader(): RemoteLoader<UiTimelineV2> =
+    fun bookmarkTimelineLoader(
+        restrict: PixivRestrict = PixivRestrict.Public,
+    ): RemoteLoader<UiTimelineV2> =
         PixivBookmarkTimelineLoader(
             service = service,
             credentialFlow = credentialFlow,
             accountKey = accountKey,
+            restrict = restrict,
         )
 
-    fun followingTimelineLoader(): RemoteLoader<UiTimelineV2> =
+    fun followingTimelineLoader(
+        restrict: PixivRestrict = PixivRestrict.Public,
+    ): RemoteLoader<UiTimelineV2> =
         PixivFollowingTimelineLoader(
             service = service,
             accountKey = accountKey,
+            restrict = restrict,
         )
 
     fun rankingTimelineLoader(mode: PixivRankingMode): RemoteLoader<UiTimelineV2> =

--- a/social/pixiv/src/commonMain/kotlin/dev/dimension/flare/data/datasource/pixiv/PixivTimelineLoaders.kt
+++ b/social/pixiv/src/commonMain/kotlin/dev/dimension/flare/data/datasource/pixiv/PixivTimelineLoaders.kt
@@ -4,6 +4,7 @@ import dev.dimension.flare.data.datasource.microblog.paging.CacheableRemoteLoade
 import dev.dimension.flare.data.datasource.microblog.paging.PagingRequest
 import dev.dimension.flare.data.datasource.microblog.paging.PagingResult
 import dev.dimension.flare.data.network.pixiv.PixivRankingMode
+import dev.dimension.flare.data.network.pixiv.PixivRestrict
 import dev.dimension.flare.data.network.pixiv.PixivSearchSort
 import dev.dimension.flare.data.network.pixiv.PixivService
 import dev.dimension.flare.data.network.pixiv.PixivWorkType
@@ -91,10 +92,19 @@ internal class PixivRankingTimelineLoader(
 internal class PixivFollowingTimelineLoader(
     service: PixivService,
     accountKey: MicroBlogKey,
+    private val restrict: PixivRestrict = PixivRestrict.Public,
 ) : PixivTimelineLoader(service, accountKey) {
-    override val pagingKey: String = "pixiv_following_$accountKey"
+    override val pagingKey: String =
+        if (restrict == PixivRestrict.Public) {
+            "pixiv_following_$accountKey"
+        } else {
+            "pixiv_following_${restrict.value}_$accountKey"
+        }
 
-    override suspend fun loadFirstPage(pageSize: Int): PixivIllustListResponse = service.followedIllusts()
+    override suspend fun loadFirstPage(pageSize: Int): PixivIllustListResponse =
+        service.followedIllusts(
+            restrict = restrict,
+        )
 }
 
 internal class PixivSearchTimelineLoader(
@@ -219,13 +229,20 @@ internal class PixivBookmarkTimelineLoader(
     service: PixivService,
     private val credentialFlow: Flow<PixivCredential>,
     accountKey: MicroBlogKey,
+    private val restrict: PixivRestrict = PixivRestrict.Public,
 ) : PixivTimelineLoader(service, accountKey) {
-    override val pagingKey: String = "pixiv_bookmark_$accountKey"
+    override val pagingKey: String =
+        if (restrict == PixivRestrict.Public) {
+            "pixiv_bookmark_$accountKey"
+        } else {
+            "pixiv_bookmark_${restrict.value}_$accountKey"
+        }
 
     override suspend fun loadFirstPage(pageSize: Int): PixivIllustListResponse {
         val credential = credentialFlow.first()
         return service.userBookmarkedIllusts(
             userId = credential.userId,
+            restrict = restrict,
         )
     }
 }

--- a/social/pixiv/src/commonMain/kotlin/dev/dimension/flare/data/platform/PixivPlatformSpec.kt
+++ b/social/pixiv/src/commonMain/kotlin/dev/dimension/flare/data/platform/PixivPlatformSpec.kt
@@ -5,6 +5,7 @@ import dev.dimension.flare.data.datasource.pixiv.PixivDataSource
 import dev.dimension.flare.data.model.tab.TimelineSpec
 import dev.dimension.flare.data.model.tab.accountLoader
 import dev.dimension.flare.data.network.pixiv.PixivRankingMode
+import dev.dimension.flare.data.network.pixiv.PixivRestrict
 import dev.dimension.flare.model.AccountType
 import dev.dimension.flare.model.MicroBlogKey
 import dev.dimension.flare.model.PlatformDataSourceContext
@@ -47,6 +48,19 @@ public data object PixivPlatformSpec :
                 },
         )
 
+    internal val privateBookmarkTimelineSpec =
+        TimelineSpec(
+            id = PIXIV_PRIVATE_BOOKMARK,
+            title = UiStrings.PixivPrivateBookmarks,
+            icon = UiIcon.Bookmark.asType(),
+            serializer = TimelineSpec.AccountBasedData.serializer(),
+            targetId = { it.accountKey.toString() },
+            loaderFactory =
+                accountLoader<PixivDataSource, TimelineSpec.AccountBasedData> {
+                    bookmarkTimelineLoader(PixivRestrict.Private)
+                },
+        )
+
     internal val followingTimelineSpec =
         TimelineSpec(
             id = PIXIV_FOLLOWING,
@@ -57,6 +71,19 @@ public data object PixivPlatformSpec :
             loaderFactory =
                 accountLoader<PixivDataSource, TimelineSpec.AccountBasedData> {
                     followingTimelineLoader()
+                },
+        )
+
+    internal val privateFollowingTimelineSpec =
+        TimelineSpec(
+            id = PIXIV_PRIVATE_FOLLOWING,
+            title = UiStrings.PixivPrivateFollowing,
+            icon = UiIcon.Follow.asType(),
+            serializer = TimelineSpec.AccountBasedData.serializer(),
+            targetId = { it.accountKey.toString() },
+            loaderFactory =
+                accountLoader<PixivDataSource, TimelineSpec.AccountBasedData> {
+                    followingTimelineLoader(PixivRestrict.Private)
                 },
         )
 
@@ -114,7 +141,9 @@ public data object PixivPlatformSpec :
             CommonTimelineSpecs.home,
             CommonTimelineSpecs.discover,
             followingTimelineSpec,
+            privateFollowingTimelineSpec,
             bookmarkTimelineSpec,
+            privateBookmarkTimelineSpec,
             rankingWeekTimelineSpec,
             rankingMonthTimelineSpec,
             rankingDayMaleTimelineSpec,
@@ -181,6 +210,8 @@ public const val PIXIV_HOST: String = "pixiv.net"
 
 private const val PIXIV_FOLLOWING: String = "pixiv.following"
 private const val PIXIV_BOOKMARK: String = "pixiv.bookmark"
+private const val PIXIV_PRIVATE_FOLLOWING: String = "pixiv.following.private"
+private const val PIXIV_PRIVATE_BOOKMARK: String = "pixiv.bookmark.private"
 private const val PIXIV_RANKING_WEEK: String = "pixiv.ranking.week"
 private const val PIXIV_RANKING_MONTH: String = "pixiv.ranking.month"
 private const val PIXIV_RANKING_DAY_MALE: String = "pixiv.ranking.day_male"

--- a/web/src/lib/i18n/uiStrings.ts
+++ b/web/src/lib/i18n/uiStrings.ts
@@ -101,6 +101,10 @@ export function localizedUiString(value: UiStrings): string {
 			return 'Supported posts';
 		case 'FanboxRecommendedCreators':
 			return 'Recommended creators';
+		case 'PixivPrivateFollowing':
+			return 'Private Following';
+		case 'PixivPrivateBookmarks':
+			return 'Private Bookmarks';
 		default:
 			return m.loginCredentialImport();
 	}


### PR DESCRIPTION
## Summary
- Add separate Pixiv private following and private bookmarks timelines using `restrict=private`.
- Add `UiStrings` entries and English titles for the new Pixiv private timeline entries across Android, Compose/Desktop, Web, and Apple.
- Preserve existing public Pixiv timeline ids and paging keys.

## Validation
- `./gradlew :social:pixiv:compileKotlinJvm :compose-ui:compileKotlinJvm`
- `./gradlew :app:compileDebugKotlin :desktopApp:compileKotlin`
- `env PATH=/Users/tlaster/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/tlaster/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin ./gradlew --no-daemon :web-shared:wasmJsBrowserDevelopmentLibraryDistribution`
- `./node_modules/.bin/svelte-kit sync`
- `./node_modules/.bin/svelte-check --tsconfig ./tsconfig.json`
- `jq empty appleApp/Shared/FlareAppleResource/Resources/Localizable.xcstrings`
- `xcodebuild -project appleApp/Flare.xcodeproj -scheme FlareAppleCore -configuration Debug -derivedDataPath /private/tmp/flare-apple-core build CODE_SIGNING_ALLOWED=NO`

Fixes #2249