### PR TITLE
Fix iOS home tab selection and icon identity

### DIFF
--- a/appleApp/Shared/FlareAppleCore/Sources/FlareAppleUI/TabIcon.swift
+++ b/appleApp/Shared/FlareAppleCore/Sources/FlareAppleUI/TabIcon.swift
@@ -39,6 +39,7 @@ public struct TabIcon: View {
         case .avatar(let avatar):
             AvatarTabIcon(userKey: avatar.accountKey, accountType: AccountType.Specific(accountKey: avatar.accountKey))
                 .frame(width: size, height: size)
+                .id("\(avatar.accountKey.id)@\(avatar.accountKey.host)")
         case .url(let url):
             NetworkImage(data: url.url)
                 .frame(width: size, height: size)
@@ -53,6 +54,7 @@ public struct TabIcon: View {
                 ) {
                     AvatarTabIcon(userKey: mixed.accountKey, accountType: AccountType.Specific(accountKey: mixed.accountKey))
                         .frame(width: size, height: size)
+                        .id("\(mixed.accountKey.id)@\(mixed.accountKey.host)")
                     MaterialTabIcon(icon: mixed.icon)
                         .padding(2)
                         .background(Color.white)
@@ -66,6 +68,7 @@ public struct TabIcon: View {
             FavTabIcon(host: favIcon.host)
                 .frame(width: size, height: size)
                 .clipShape(RoundedRectangle(cornerRadius: faviconCornerRadius, style: .continuous))
+                .id(favIcon.host)
         }
     }
 }

--- a/appleApp/ios/UI/Screen/HomeTimelineScreen.swift
+++ b/appleApp/ios/UI/Screen/HomeTimelineScreen.swift
@@ -14,7 +14,7 @@ struct HomeTimelineScreen: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.timelineAppearance) private var timelineAppearance
     @Environment(\.openURL) private var openURL
-    @State private var selectedTabIndex = 0
+    @State private var selectedTabId: String?
     @Namespace private var selectedTabIndicatorNamespace
     @StateObject private var presenter: KotlinPresenter<HomeTimelineWithTabsPresenterState>
     @StateObject private var activeAccountPresenter = KotlinPresenter(presenter: ActiveAccountPresenter())
@@ -78,17 +78,20 @@ struct HomeTimelineScreen: View {
                             }
                         }
                     } else {
-                        let tab = tabs[min(max(selectedTabIndex, 0), tabs.count - 1)]
+                        let tab = selectedTabId.flatMap { id in
+                            tabs.first { $0.id == id }
+                        } ?? tabs[0]
                         ZStack {
                             TimelineScreen(tabItem: tab, allowGalleryMode: true)
                                 .environment(\.timelineAppearance, tab.resolveTimelineAppearance(base: timelineAppearance))
                                 .id(tab.id)
                         }
-                        .onChange(of: state.count, { oldValue, newValue in
-                            if !(tabs.indices.contains(selectedTabIndex)) {
-                                selectedTabIndex = 0
+                        .onChange(of: tabs.map { $0.id }, initial: true) { _, tabIds in
+                            if let selectedTabId, tabIds.contains(selectedTabId) {
+                                return
                             }
-                        })
+                            selectedTabId = tabIds.first
+                        }
                         .toolbar {
                             leadingToolbarContent
                             if horizontalSizeClass == .compact {
@@ -99,15 +102,15 @@ struct HomeTimelineScreen: View {
                                         TabIcon(tabItem: tab)
                                     }
                                     .labelStyle(.titleAndIcon)
+                                    .id(tab.id)
                                 }
                                 ToolbarTitleMenu {
-                                    ForEach(0..<tabs.count, id: \.self) { index in
-                                        let item = tabs[index]
+                                    ForEach(tabs, id: \.id) { item in
                                         Toggle(isOn: Binding(get: {
-                                            selectedTabIndex == index
+                                            tab.id == item.id
                                         }, set: { value in
                                             if value {
-                                                selectedTabIndex = index
+                                                selectedTabId = item.id
                                             }
                                         })) {
                                             Label {
@@ -135,10 +138,9 @@ struct HomeTimelineScreen: View {
                                 ToolbarItem(placement: .automatic) {
                                     ScrollView(.horizontal) {
                                         HStack {
-                                            ForEach(0..<tabs.count, id: \.self) { index in
-                                                let item = tabs[index]
+                                            ForEach(tabs, id: \.id) { item in
                                                 Button {
-                                                    selectedTabIndex = index
+                                                    selectedTabId = item.id
                                                 } label: {
                                                     Label {
                                                         TimelineTabTitle(title: item.title)
@@ -152,7 +154,7 @@ struct HomeTimelineScreen: View {
                                                 .padding(.bottom, 9)
                                                 .ignoresSafeArea(edges: .bottom)
                                                 .safeAreaInset(edge: .bottom) {
-                                                    if selectedTabIndex == index {
+                                                    if tab.id == item.id {
                                                         Capsule()
                                                             .fill(Color.accentColor)
                                                             .frame(width: 18, height: 3)
@@ -165,7 +167,7 @@ struct HomeTimelineScreen: View {
                                             }
                                         }
                                         .padding(.horizontal)
-                                        .animation(.spring(response: 0.25, dampingFraction: 0.85), value: selectedTabIndex)
+                                        .animation(.spring(response: 0.25, dampingFraction: 0.85), value: selectedTabId)
                                     }
                                 }
                                 if #available(iOS 26.0, *) {
@@ -243,8 +245,7 @@ private struct DeckTimelineLayout: View {
     var body: some View {
         ScrollView(.horizontal) {
             LazyHStack(alignment: .top, spacing: 0) {
-                ForEach(0..<tabs.count, id: \.self) { index in
-                    let tab = tabs[index]
+                ForEach(tabs, id: \.id) { tab in
                     DeckTimelineColumnRoot(
                         tabItem: tab,
                         baseTimelineAppearance: baseTimelineAppearance,
@@ -254,7 +255,7 @@ private struct DeckTimelineLayout: View {
                     .ignoresSafeArea()
                     .frame(width: columnWidth)
                     .frame(maxHeight: .infinity)
-                    if index < tabs.count - 1 {
+                    if tab.id != tabs.last?.id {
                         Divider()
                             .ignoresSafeArea()
                     }


### PR DESCRIPTION
## Summary

- preserve the selected iOS home timeline by stable tab ID instead of array index
- identify home tab menu, horizontal tab, and deck items by tab ID
- rebuild toolbar, avatar, and favicon views when their backing tab/account/host changes

## Root cause

The iOS home screen stored selection as an array index and keyed several SwiftUI collections by that index. After tabs were inserted, removed, reordered, or refreshed following reauthentication, SwiftUI could reuse a view for a different timeline. Stateful avatar and favicon views then retained presenters created for the previous account or host, leaving the toolbar icon out of sync with the actual timeline.

## User impact

The selected timeline remains stable across tab list updates, and the toolbar/menu icons track the correct account or host instead of displaying a stale icon.

## Validation

- `git diff --check`
- `xcodebuild -project Flare.xcodeproj -scheme iOS -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/flare-ios-derived CODE_SIGNING_ALLOWED=NO build`
