### PR TITLE
feat(settings): add OrcaRouter to AI server URL suggestions

### DIFF
--- a/shared/src/commonMain/kotlin/dev/dimension/flare/ui/presenter/settings/AiConfigPresenter.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/ui/presenter/settings/AiConfigPresenter.kt
@@ -641,6 +641,7 @@ private val SERVER_SUGGESTIONS =
         "https://api.openai.com/v1/",
         "https://generativelanguage.googleapis.com/v1beta/openai/",
         "https://openrouter.ai/api/v1/",
+        "https://api.orcarouter.ai/v1/",
         "https://api.x.ai/v1/",
         "https://dashscope.aliyuncs.com/compatible-mode/v1/",
         "https://open.bigmodel.cn/api/paas/v4/",


### PR DESCRIPTION
## Summary

Adds **[OrcaRouter](https://www.orcarouter.ai)** to the preset server-URL suggestions in the AI settings dialog, so it can be selected with one tap just like the existing OpenAI, OpenRouter, Gemini, xAI and other presets. OrcaRouter is an OpenAI-compatible model gateway with Anthropic-compatible endpoints too, which is exactly what Flare's built-in AI agent already speaks — and it also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## What this changes

- `AiConfigPresenter.kt`: adds `https://api.orcarouter.ai/v1/` to `SERVER_SUGGESTIONS`, next to the existing `https://openrouter.ai/api/v1/` entry.

That's it — the AI config dialog's server-URL field gets OrcaRouter as a suggestion, and the existing model picker (which queries `{serverUrl}/models`) then lists OrcaRouter's catalog automatically. Model IDs are namespaced (`anthropic/claude-sonnet-5`, `z-ai/glm-4.6`, etc.), so the live model list is what makes this usable out of the box.

## Why this preset

Flare already names a dozen OpenAI-compatible endpoints as one-tap suggestions (OpenAI, OpenRouter, Gemini, xAI, DeepSeek, Groq, …). This mirrors that exact pattern for OrcaRouter rather than expecting users to know the base URL by heart, and it's the same integration shape the model picker already supports.

## Verification

- `GET {serverUrl}/models` with an `sk-orca-` key → HTTP 200, 206 models including `anthropic/claude-sonnet-5`, `z-ai/glm-4.6`, `openai/gpt-5-mini` (this is the exact call `OpenAIModelsPresenter` makes)
- `POST {serverUrl}/chat/completions` with `anthropic/claude-sonnet-5` → model replies (this is the exact call `OpenAIService.chatCompletion` makes)

I'm an engineer on the OrcaRouter team.
