### PR TITLE
fix(ios): prevent profile jump after timeline updates

### DIFF
--- a/appleApp/ios/UI/Component/CollectionViewTimeline.swift
+++ b/appleApp/ios/UI/Component/CollectionViewTimeline.swift
@@ -135,6 +135,7 @@ final class UITimelineCollectionViewController: UIViewController, UICollectionVi
     var onScrollInteractionBegan: (() -> Void)?
     var openURL: ((URL) -> Void)?
     var suppressInitialRefreshIndicator = false
+    var restoresScrollAnchorOnSnapshotChanges = true
     var usesGroupedBackgroundOverride: Bool? {
         didSet {
             guard oldValue != usesGroupedBackgroundOverride, isViewLoaded else { return }
@@ -1558,7 +1559,8 @@ final class UITimelineCollectionViewController: UIViewController, UICollectionVi
         var snapshot = preparedSnapshot
         let newSignature = plan.signature
         let previousSignature = lastAppliedSignature
-        let scrollAnchor = pendingEffectiveContentOffsetYAfterSnapshot == nil &&
+        let scrollAnchor = restoresScrollAnchorOnSnapshotChanges &&
+            pendingEffectiveContentOffsetYAfterSnapshot == nil &&
             previousSignature != nil &&
             previousSignature?.itemIDs != newSignature.itemIDs &&
             allowsScrollAnchorRestoration

--- a/appleApp/ios/UI/Screen/ProfileScreen.swift
+++ b/appleApp/ios/UI/Screen/ProfileScreen.swift
@@ -675,6 +675,7 @@ private struct ProfileTimelineCollectionView: UIViewControllerRepresentable {
             controller.extendsContentUnderTopBars = extendsContentUnderTopBars
             controller.topScrollIndicatorInset = 0
             controller.suppressInitialRefreshIndicator = true
+            controller.restoresScrollAnchorOnSnapshotChanges = false
             controller.accessoryItems = []
             controller.openURL = { url in
                 openURL.callAsFunction(url)


### PR DESCRIPTION
## Summary

- add an opt-out for snapshot-driven scroll anchor restoration
- disable it only for profile timelines so newly inserted content does not push the profile header upward
- keep the default timeline behavior, explicit tab offset restoration, and media geometry restoration unchanged

## Testing

- `git diff --check`
- iOS Debug simulator build using an XcodeGen-generated project