### PR TITLE
fix(android): make long alt text scrollable

### DIFF
--- a/app/src/androidTest/java/dev/dimension/flare/ui/screen/status/action/AltTextSheetTest.kt
+++ b/app/src/androidTest/java/dev/dimension/flare/ui/screen/status/action/AltTextSheetTest.kt
@@ -1,0 +1,60 @@
+package dev.dimension.flare.ui.screen.status.action
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.unit.dp
+import org.junit.Rule
+import org.junit.Test
+
+class AltTextSheetTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun longAltTextCanBeScrolled() {
+        val longAltText = List(30) { "Long alternative text" }.joinToString("\n")
+
+        composeRule.setContent {
+            MaterialTheme {
+                Box(
+                    modifier =
+                        Modifier
+                            .width(360.dp)
+                            .height(320.dp),
+                ) {
+                    AltTextSheet(
+                        text = longAltText,
+                        onBack = {},
+                    )
+                }
+            }
+        }
+
+        val scrollableContent = composeRule.onNode(hasScrollAction())
+        val hasVerticalOverflow =
+            SemanticsMatcher("has vertical overflow") { node ->
+                node.config[SemanticsProperties.VerticalScrollAxisRange].maxValue() > 0f
+            }
+
+        scrollableContent.assert(hasVerticalOverflow)
+        scrollableContent.performSemanticsAction(SemanticsActions.ScrollBy) { scrollBy ->
+            scrollBy(0f, Float.MAX_VALUE)
+        }
+        scrollableContent.assert(
+            SemanticsMatcher("has scrolled to the bottom") { node ->
+                val scrollRange = node.config[SemanticsProperties.VerticalScrollAxisRange]
+                scrollRange.value() == scrollRange.maxValue()
+            },
+        )
+    }
+}

--- a/app/src/main/java/dev/dimension/flare/ui/screen/status/action/AltTextSheet.kt
+++ b/app/src/main/java/dev/dimension/flare/ui/screen/status/action/AltTextSheet.kt
@@ -3,6 +3,8 @@ package dev.dimension.flare.ui.screen.status.action
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,6 +23,7 @@ internal fun AltTextSheet(
     Column(
         modifier =
             modifier
+                .verticalScroll(rememberScrollState())
                 .padding(horizontal = screenHorizontalPadding)
                 .padding(bottom = 8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),


### PR DESCRIPTION
## Summary

- make Android ALT text sheets vertically scrollable when content exceeds the viewport
- add Compose UI regression coverage that confirms overflowing text can reach the bottom

## Root cause

`AltTextSheet` rendered content in a static `Column`, so the bottom sheet clipped text taller than its viewport without exposing a scroll action.

## Testing

- `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.dimension.flare.ui.screen.status.action.AltTextSheetTest`
- `./gradlew :app:ktlintCheck :app:testDebugUnitTest :app:connectedDebugAndroidTest`
- `./gradlew :app:ktlintFormat :app:lintDebug`

Fixes #2443