### PR TITLE
fix(fanbox): support current API response shapes

### DIFF
--- a/social/fanbox/src/commonMain/kotlin/dev/dimension/flare/data/datasource/fanbox/FanboxMapper.kt
+++ b/social/fanbox/src/commonMain/kotlin/dev/dimension/flare/data/datasource/fanbox/FanboxMapper.kt
@@ -34,6 +34,7 @@ import dev.dimension.flare.ui.render.RenderBlockStyle
 import dev.dimension.flare.ui.render.RenderContent
 import dev.dimension.flare.ui.render.RenderRun
 import dev.dimension.flare.ui.render.RenderTextStyle
+import dev.dimension.flare.ui.render.parseHtml
 import dev.dimension.flare.ui.render.toUi
 import dev.dimension.flare.ui.render.toUiPlainText
 import dev.dimension.flare.ui.route.DeeplinkRoute
@@ -136,6 +137,8 @@ internal fun FanboxPostDetailBody.toUiArticle(
                 body
                     ?.toArticleBlocks(
                         postId = id,
+                        postType = type,
+                        sourceUrl = sourceUrl,
                         sensitive = hasAdultContent,
                         imageHeaders = imageHeaders,
                     ).orEmpty()
@@ -341,14 +344,47 @@ private fun FanboxUserEntity.profileRoute(
 
 private fun FanboxPostDetailBody.BodyContent.toArticleBlocks(
     postId: String,
+    postType: String,
+    sourceUrl: String,
     sensitive: Boolean,
     imageHeaders: ImmutableMap<String, String>? = null,
 ): List<UiArticleBlock> {
+    if (postType == "entry" && !html.isNullOrBlank()) {
+        val htmlBlocks =
+            html.toArticleHtmlBlocks(
+                keyPrefix = "$postId:html",
+                sensitive = sensitive,
+                imageHeaders = imageHeaders,
+            )
+        if (htmlBlocks.isNotEmpty()) {
+            return htmlBlocks
+        }
+    }
+
+    if (postType == "video") {
+        val videoBlocks =
+            buildList<UiArticleBlock> {
+                text
+                    ?.takeIf { it.isNotBlank() }
+                    ?.toArticleTextBlock(key = "$postId:text")
+                    ?.let(::add)
+                video
+                    ?.toArticleEmbedBlock(
+                        key = "$postId:video",
+                        fallbackUrl = sourceUrl,
+                    )?.let(::add)
+            }
+        if (videoBlocks.isNotEmpty()) {
+            return videoBlocks
+        }
+    }
+
     if (blocks.isNotEmpty()) {
         return blocks.flatMapIndexed { index, block ->
             block.toArticleBlocks(
                 keyPrefix = "$postId:block:$index",
                 content = this,
+                sourceUrl = sourceUrl,
                 sensitive = sensitive,
                 imageHeaders = imageHeaders,
             )
@@ -381,6 +417,7 @@ private fun FanboxPostDetailBody.BodyContent.toArticleBlocks(
 private fun FanboxPostDetailBody.Block.toArticleBlocks(
     keyPrefix: String,
     content: FanboxPostDetailBody.BodyContent,
+    sourceUrl: String,
     sensitive: Boolean,
     imageHeaders: ImmutableMap<String, String>? = null,
 ): List<UiArticleBlock> {
@@ -389,6 +426,8 @@ private fun FanboxPostDetailBody.Block.toArticleBlocks(
             it.toArticleTextBlock(
                 key = keyPrefix,
                 headingLevel = type.toArticleHeadingLevel(),
+                styles = styles.orEmpty(),
+                links = links.orEmpty(),
             ),
         )
     }
@@ -417,8 +456,17 @@ private fun FanboxPostDetailBody.Block.toArticleBlocks(
             return listOf(
                 it.toArticleEmbedBlock(
                     key = "$keyPrefix:embed:${it.id}",
+                    fallbackUrl = sourceUrl,
                 ),
             )
+        }
+    embedId
+        ?.let(content.embedMap::get)
+        ?.toArticleEmbedBlock(
+            key = "$keyPrefix:embed:$embedId",
+            fallbackUrl = sourceUrl,
+        )?.let {
+            return listOf(it)
         }
     return emptyList()
 }
@@ -426,49 +474,147 @@ private fun FanboxPostDetailBody.Block.toArticleBlocks(
 private fun String.toArticleTextBlock(
     key: String,
     headingLevel: Int? = null,
+    styles: List<FanboxPostDetailBody.Style> = emptyList(),
+    links: List<FanboxPostDetailBody.Link> = emptyList(),
 ): UiArticleBlock.Text =
     UiArticleBlock.Text(
         key = key,
         content =
             RenderContent.Text(
-                runs = toArticleTextRuns().toImmutableList(),
+                runs = toArticleTextRuns(styles, links).toImmutableList(),
                 block = RenderBlockStyle(headingLevel = headingLevel),
             ),
     )
 
-private fun String.toArticleTextRuns(): List<RenderRun.Text> =
-    buildList {
-        var previousEnd = 0
-        FANBOX_ARTICLE_URL_REGEX.findAll(this@toArticleTextRuns).forEach { match ->
-            if (match.range.first > previousEnd) {
-                add(RenderRun.Text(text = substring(previousEnd, match.range.first)))
+private fun String.toArticleTextRuns(
+    styles: List<FanboxPostDetailBody.Style>,
+    links: List<FanboxPostDetailBody.Link>,
+): List<RenderRun.Text> {
+    val styleRanges =
+        styles.mapNotNull { style ->
+            val offset = style.offset ?: return@mapNotNull null
+            val spanLength = style.length ?: return@mapNotNull null
+            val type = style.type ?: return@mapNotNull null
+            fanboxTextRange(offset, spanLength, length)?.let { it to type }
+        }
+    val explicitLinkRanges =
+        links.mapNotNull { link ->
+            val offset = link.offset ?: return@mapNotNull null
+            val spanLength = link.length ?: return@mapNotNull null
+            link.url
+                ?.httpUrlOrNull()
+                ?.let { url -> fanboxTextRange(offset, spanLength, length)?.let { it to url } }
+        }
+    val detectedLinkRanges =
+        FANBOX_ARTICLE_URL_REGEX
+            .findAll(this)
+            .mapNotNull { match ->
+                match.value
+                    .trimEndUrlPunctuation()
+                    .takeIf { it.isNotEmpty() }
+                    ?.let { url -> (match.range.first until match.range.first + url.length) to url }
+            }.toList()
+    val linkRanges = explicitLinkRanges + detectedLinkRanges
+    val boundaries =
+        buildSet {
+            add(0)
+            add(length)
+            (styleRanges + linkRanges).forEach { (range) ->
+                add(range.first)
+                add(range.last + 1)
             }
-            val rawUrl = match.value
-            val url = rawUrl.trimEndUrlPunctuation()
-            if (url.isNotEmpty()) {
-                add(
-                    RenderRun.Text(
-                        text = url,
-                        style = RenderTextStyle(link = url),
-                    ),
+        }.sorted()
+
+    return boundaries
+        .zipWithNext()
+        .mapNotNull { (start, endExclusive) ->
+            if (start >= endExclusive) {
+                return@mapNotNull null
+            }
+            var style =
+                RenderTextStyle(
+                    link = linkRanges.firstOrNull { (range) -> start in range }?.second,
                 )
+            styleRanges.forEach { (range, type) ->
+                if (start in range) {
+                    style = style.withFanboxStyle(type)
+                }
             }
-            val suffix = rawUrl.removePrefix(url)
-            if (suffix.isNotEmpty()) {
-                add(RenderRun.Text(text = suffix))
-            }
-            previousEnd = match.range.last + 1
-        }
-        if (previousEnd < this@toArticleTextRuns.length) {
-            add(RenderRun.Text(text = substring(previousEnd)))
-        }
-        if (isEmpty()) {
-            add(RenderRun.Text(text = this@toArticleTextRuns))
-        }
+            RenderRun.Text(
+                text = substring(start, endExclusive),
+                style = style,
+            )
+        }.ifEmpty { listOf(RenderRun.Text(text = this)) }
+}
+
+private fun fanboxTextRange(
+    offset: Int,
+    length: Int,
+    textLength: Int,
+): IntRange? {
+    if (offset < 0 || offset >= textLength || length <= 0) {
+        return null
+    }
+    val endExclusive = minOf(textLength.toLong(), offset.toLong() + length.toLong()).toInt()
+    return (offset until endExclusive).takeUnless { it.isEmpty() }
+}
+
+private fun RenderTextStyle.withFanboxStyle(type: String): RenderTextStyle =
+    when (type.lowercase()) {
+        "bold" -> copy(bold = true)
+        "italic" -> copy(italic = true)
+        "strike", "strikethrough" -> copy(strikethrough = true)
+        "underline" -> copy(underline = true)
+        "code", "monospace" -> copy(monospace = true, code = true)
+        else -> this
     }
 
 private fun String.trimEndUrlPunctuation(): String =
     trimEnd('.', ',', '!', '?', ';', ':', ')', ']', '}', '>', '。', '、', '，', '！', '？', '；', '：')
+
+private fun String.httpUrlOrNull(): String? =
+    trim().takeIf {
+        it.startsWith("https://", ignoreCase = true) || it.startsWith("http://", ignoreCase = true)
+    }
+
+private fun String.toArticleHtmlBlocks(
+    keyPrefix: String,
+    sensitive: Boolean,
+    imageHeaders: ImmutableMap<String, String>? = null,
+): List<UiArticleBlock> =
+    parseHtml(this)
+        .toUi()
+        .renderRuns
+        .mapIndexedNotNull { index, content ->
+            when (content) {
+                is RenderContent.Text -> {
+                    UiArticleBlock.Text(
+                        key = "$keyPrefix:$index",
+                        content = content,
+                    )
+                }
+
+                is RenderContent.BlockImage -> {
+                    content.url
+                        .takeIf { it.isNotBlank() }
+                        ?.let { url ->
+                            UiArticleBlock.Image(
+                                key = "$keyPrefix:image:$index",
+                                media =
+                                    UiMedia.Image(
+                                        url = url,
+                                        previewUrl = url,
+                                        description = null,
+                                        height = 0f,
+                                        width = 0f,
+                                        sensitive = sensitive,
+                                        customHeaders = imageHeaders,
+                                    ),
+                            )
+                        }
+                }
+            }
+        }
 
 private fun String.toArticleHeadingLevel(): Int? =
     when (this) {
@@ -552,10 +698,57 @@ private fun FanboxPostDetailBody.FileItem.articleFileExtension(): String =
         .orEmpty()
         .lowercase()
 
-private fun FanboxPostDetailBody.UrlEmbed.toArticleEmbedBlock(key: String): UiArticleBlock.Embed =
+private fun FanboxPostDetailBody.ProviderEmbed.toArticleEmbedBlock(
+    key: String,
+    fallbackUrl: String,
+): UiArticleBlock.Embed? {
+    val provider = serviceProvider?.trim()?.takeIf { it.isNotEmpty() }
+    val id = (videoId ?: contentId)?.trim()?.takeIf { it.isNotEmpty() }
+    if (provider == null && id == null) {
+        return null
+    }
+    return UiArticleBlock.Embed(
+        key = key,
+        url = fanboxProviderUrl(provider, id) ?: fallbackUrl,
+        title = provider?.toFanboxProviderTitle(),
+    )
+}
+
+private fun fanboxProviderUrl(
+    provider: String?,
+    contentId: String?,
+): String? {
+    val id = contentId ?: return null
+    id.httpUrlOrNull()?.let {
+        return it
+    }
+    return when (provider?.lowercase()) {
+        "youtube" -> "https://www.youtube.com/watch?v=$id"
+        "vimeo" -> "https://vimeo.com/$id"
+        "twitter" -> "https://x.com/i/web/status/$id"
+        "google_forms" -> "https://docs.google.com/forms/d/e/$id/viewform"
+        else -> null
+    }
+}
+
+private fun String.toFanboxProviderTitle(): String =
+    when (lowercase()) {
+        "youtube" -> "YouTube"
+        "vimeo" -> "Vimeo"
+        "twitter" -> "X / Twitter"
+        "soundcloud" -> "SoundCloud"
+        "google_forms" -> "Google Forms"
+        "fanbox" -> "pixivFANBOX"
+        else -> replace('_', ' ')
+    }
+
+private fun FanboxPostDetailBody.UrlEmbed.toArticleEmbedBlock(
+    key: String,
+    fallbackUrl: String,
+): UiArticleBlock.Embed =
     UiArticleBlock.Embed(
         key = key,
-        url = postInfo?.let { fanboxPostUrl(it.creatorId, it.id) },
+        url = url?.httpUrlOrNull() ?: postInfo?.let { fanboxPostUrl(it.creatorId, it.id) } ?: fallbackUrl,
         title = postInfo?.title,
         description = postInfo?.excerpt?.takeIf { it.isNotBlank() },
         imageUrl = postInfo?.cover?.url,

--- a/social/fanbox/src/commonMain/kotlin/dev/dimension/flare/data/datasource/fanbox/FanboxTimelineLoaders.kt
+++ b/social/fanbox/src/commonMain/kotlin/dev/dimension/flare/data/datasource/fanbox/FanboxTimelineLoaders.kt
@@ -118,7 +118,7 @@ internal class FanboxCreatorTimelineLoader(
         nextKey: String?,
     ): FanboxPostPage {
         val creatorId = creatorKey.resolveCreatorId() ?: return FanboxPostPage(emptyList(), null)
-        val pages = service.paginateCreatorPosts(creatorId = creatorId).body
+        val pages = service.paginateCreatorPosts(creatorId = creatorId).body.pageUrls
         val currentPage = nextKey ?: pages.firstOrNull()
         val nextPage =
             currentPage
@@ -140,7 +140,7 @@ internal class FanboxCreatorTimelineLoader(
                 maxId = cursor.maxId,
             )
         return FanboxPostPage(
-            items = response.body,
+            items = response.body.posts,
             nextKey = nextPage,
         )
     }

--- a/social/fanbox/src/commonMain/kotlin/dev/dimension/flare/data/network/fanbox/FanboxModels.kt
+++ b/social/fanbox/src/commonMain/kotlin/dev/dimension/flare/data/network/fanbox/FanboxModels.kt
@@ -123,14 +123,26 @@ internal data class FanboxPostListResponse(
 @Serializable
 internal data class FanboxCreatorPostListResponse(
     @SerialName("body")
-    val body: List<FanboxPostEntity> = emptyList(),
-)
+    val body: Body = Body(),
+) {
+    @Serializable
+    internal data class Body(
+        @SerialName("posts")
+        val posts: List<FanboxPostEntity> = emptyList(),
+    )
+}
 
 @Serializable
 internal data class FanboxCreatorPostPagesResponse(
     @SerialName("body")
-    val body: List<String> = emptyList(),
-)
+    val body: Body = Body(),
+) {
+    @Serializable
+    internal data class Body(
+        @SerialName("pageUrls")
+        val pageUrls: List<String> = emptyList(),
+    )
+}
 
 @Serializable
 internal data class FanboxPostSearchResponse(
@@ -202,8 +214,14 @@ internal data class FanboxPostDetailBody(
     internal data class BodyContent(
         @SerialName("text")
         val text: String? = null,
+        @SerialName("video")
+        val video: ProviderEmbed? = null,
+        @SerialName("html")
+        val html: String? = null,
         @SerialName("blocks")
         val blocks: List<Block> = emptyList(),
+        @SerialName("embedMap")
+        val embedMap: Map<String, ProviderEmbed> = emptyMap(),
         @SerialName("fileMap")
         val fileMap: Map<String, FileItem> = emptyMap(),
         @SerialName("imageMap")
@@ -228,6 +246,42 @@ internal data class FanboxPostDetailBody(
         val fileId: String? = null,
         @SerialName("urlEmbedId")
         val urlEmbedId: String? = null,
+        @SerialName("embedId")
+        val embedId: String? = null,
+        @SerialName("styles")
+        val styles: List<Style>? = null,
+        @SerialName("links")
+        val links: List<Link>? = null,
+    )
+
+    @Serializable
+    internal data class Style(
+        @SerialName("type")
+        val type: String? = null,
+        @SerialName("offset")
+        val offset: Int? = null,
+        @SerialName("length")
+        val length: Int? = null,
+    )
+
+    @Serializable
+    internal data class Link(
+        @SerialName("offset")
+        val offset: Int? = null,
+        @SerialName("length")
+        val length: Int? = null,
+        @SerialName("url")
+        val url: String? = null,
+    )
+
+    @Serializable
+    internal data class ProviderEmbed(
+        @SerialName("serviceProvider")
+        val serviceProvider: String? = null,
+        @SerialName("videoId")
+        val videoId: String? = null,
+        @SerialName("contentId")
+        val contentId: String? = null,
     )
 
     @Serializable
@@ -266,6 +320,8 @@ internal data class FanboxPostDetailBody(
         val id: String = "",
         @SerialName("type")
         val type: String = "",
+        @SerialName("url")
+        val url: String? = null,
         @SerialName("html")
         val html: String? = null,
         @SerialName("postInfo")

--- a/social/fanbox/src/commonTest/kotlin/dev/dimension/flare/data/datasource/fanbox/FanboxMapperTest.kt
+++ b/social/fanbox/src/commonTest/kotlin/dev/dimension/flare/data/datasource/fanbox/FanboxMapperTest.kt
@@ -1,12 +1,15 @@
 package dev.dimension.flare.data.datasource.fanbox
 
+import dev.dimension.flare.common.JSON
 import dev.dimension.flare.data.network.fanbox.FanboxPostDetailBody
+import dev.dimension.flare.data.network.fanbox.FanboxPostDetailResponse
 import dev.dimension.flare.model.MicroBlogKey
 import dev.dimension.flare.ui.model.UiArticleBlock
 import dev.dimension.flare.ui.render.RenderRun
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 class FanboxMapperTest {
     @Test
@@ -39,5 +42,149 @@ class FanboxMapperTest {
         assertEquals("https://example.org/path", runs[3].text)
         assertEquals("https://example.org/path", runs[3].style.link)
         assertEquals(".", runs[4].text)
+    }
+
+    @Test
+    fun articlePreservesTextMetadataAndEmbeds() {
+        val article = decodeArticle(MODERN_ARTICLE_RESPONSE)
+        val blocks = article.content.blocks
+
+        val textBlock = assertIs<UiArticleBlock.Text>(blocks[0])
+        val runs = textBlock.content.runs.map { assertIs<RenderRun.Text>(it) }
+        val linkedRun = runs.single { it.text == "this" }
+        val clampedRun = runs.single { it.text == "link" }
+        assertTrue(linkedRun.style.bold)
+        assertEquals("https://example.com/linked", linkedRun.style.link)
+        assertTrue(clampedRun.style.italic)
+
+        val urlEmbed = assertIs<UiArticleBlock.Embed>(blocks[1])
+        assertEquals("https://example.com/article", urlEmbed.url)
+
+        val providerEmbed = assertIs<UiArticleBlock.Embed>(blocks[2])
+        assertEquals("YouTube", providerEmbed.title)
+        assertEquals("https://www.youtube.com/watch?v=abc123", providerEmbed.url)
+
+        val unknownProviderEmbed = assertIs<UiArticleBlock.Embed>(blocks[3])
+        assertEquals("new service", unknownProviderEmbed.title)
+        assertEquals("https://www.fanbox.cc/@creator/posts/post", unknownProviderEmbed.url)
+    }
+
+    @Test
+    fun legacyVideoPostMapsProviderEmbed() {
+        val article = decodeArticle(LEGACY_VIDEO_RESPONSE)
+        val block = assertIs<UiArticleBlock.Embed>(article.content.blocks.single())
+
+        assertEquals("Vimeo", block.title)
+        assertEquals("https://vimeo.com/12345", block.url)
+    }
+
+    @Test
+    fun legacyEntryPostUsesHtmlRenderer() {
+        val article = decodeArticle(LEGACY_ENTRY_RESPONSE)
+        val block = assertIs<UiArticleBlock.Text>(article.content.blocks.single())
+        val runs = block.content.runs.map { assertIs<RenderRun.Text>(it) }
+
+        assertEquals("Hello world.", runs.joinToString(separator = "") { it.text })
+        assertTrue(runs.single { it.text == "world" }.style.bold)
+    }
+
+    private fun decodeArticle(response: String) =
+        JSON
+            .decodeFromString(FanboxPostDetailResponse.serializer(), response)
+            .body
+            .toUiArticle(accountKey = MicroBlogKey(id = "1", host = "fanbox.cc"))
+
+    private companion object {
+        val MODERN_ARTICLE_RESPONSE =
+            """
+            {
+              "body": {
+                "post": {
+                  "id": "post",
+                  "creatorId": "creator",
+                  "publishedDatetime": "2024-01-02T03:04:05+00:00",
+                  "type": "article",
+                  "body": {
+                    "blocks": [
+                      {
+                        "type": "p",
+                        "text": "Read this link",
+                        "styles": [
+                          { "type": "bold", "offset": 5, "length": 4 },
+                          { "type": "italic", "offset": 10, "length": 100 },
+                          { "type": "underline", "offset": 100, "length": 1 }
+                        ],
+                        "links": [
+                          { "offset": 5, "length": 4, "url": "https://example.com/linked" }
+                        ]
+                      },
+                      {
+                        "type": "url_embed",
+                        "urlEmbedId": "url-1",
+                        "styles": null,
+                        "links": null
+                      },
+                      { "type": "embed", "embedId": "embed-1" },
+                      { "type": "embed", "embedId": "embed-2" }
+                    ],
+                    "urlEmbedMap": {
+                      "url-1": {
+                        "id": "url-1",
+                        "type": "html.card",
+                        "url": "https://example.com/article"
+                      }
+                    },
+                    "embedMap": {
+                      "embed-1": {
+                        "serviceProvider": "youtube",
+                        "videoId": "abc123"
+                      },
+                      "embed-2": {
+                        "serviceProvider": "new_service",
+                        "contentId": "opaque-id"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """.trimIndent()
+
+        val LEGACY_VIDEO_RESPONSE =
+            """
+            {
+              "body": {
+                "post": {
+                  "id": "video-post",
+                  "creatorId": "creator",
+                  "publishedDatetime": "2024-01-02T03:04:05+00:00",
+                  "type": "video",
+                  "body": {
+                    "video": {
+                      "serviceProvider": "vimeo",
+                      "videoId": "12345"
+                    }
+                  }
+                }
+              }
+            }
+            """.trimIndent()
+
+        val LEGACY_ENTRY_RESPONSE =
+            """
+            {
+              "body": {
+                "post": {
+                  "id": "entry-post",
+                  "creatorId": "creator",
+                  "publishedDatetime": "2024-01-02T03:04:05+00:00",
+                  "type": "entry",
+                  "body": {
+                    "html": "<p>Hello <strong>world</strong>.</p>"
+                  }
+                }
+              }
+            }
+            """.trimIndent()
     }
 }

--- a/social/fanbox/src/commonTest/kotlin/dev/dimension/flare/data/network/fanbox/FanboxCreatorPostResponseTest.kt
+++ b/social/fanbox/src/commonTest/kotlin/dev/dimension/flare/data/network/fanbox/FanboxCreatorPostResponseTest.kt
@@ -1,0 +1,34 @@
+package dev.dimension.flare.data.network.fanbox
+
+import dev.dimension.flare.common.JSON
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FanboxCreatorPostResponseTest {
+    @Test
+    fun creatorPostPagesAreDecodedFromPageUrls() {
+        val response =
+            JSON.decodeFromString(
+                FanboxCreatorPostPagesResponse.serializer(),
+                """{"body":{"pageUrls":["https://api.fanbox.cc/post.listCreator?creatorId=sample"]}}""",
+            )
+
+        assertEquals(1, response.body.pageUrls.size)
+    }
+
+    @Test
+    fun creatorPostsAreDecodedFromPosts() {
+        val response =
+            JSON.decodeFromString(
+                FanboxCreatorPostListResponse.serializer(),
+                """{"body":{"posts":[{"id":"sample-post","title":"Sample post"}]}}""",
+            )
+
+        assertEquals(
+            "sample-post",
+            response.body.posts
+                .single()
+                .id,
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- update creator post list/page response models for the current `body` wrappers
- support article `embedMap`, styled and linked text, URL/provider embeds, and legacy video/entry bodies
- add decoding and mapper coverage for modern and legacy FANBOX posts

## Testing
- `./gradlew :social:fanbox:jvmTest`
- `./gradlew :social:fanbox:ktlintCommonMainSourceSetCheck :social:fanbox:ktlintCommonTestSourceSetCheck`