### PR TITLE
fix(misskey): show complete thread context in status detail

### DIFF
--- a/social/misskey/src/commonMain/kotlin/dev/dimension/flare/data/datasource/misskey/StatusDetailRemoteMediator.kt
+++ b/social/misskey/src/commonMain/kotlin/dev/dimension/flare/data/datasource/misskey/StatusDetailRemoteMediator.kt
@@ -6,7 +6,9 @@ import dev.dimension.flare.data.datasource.microblog.paging.PagingRequest
 import dev.dimension.flare.data.datasource.microblog.paging.PagingResult
 import dev.dimension.flare.data.network.misskey.MisskeyService
 import dev.dimension.flare.data.network.misskey.api.model.IPinRequest
+import dev.dimension.flare.data.network.misskey.api.model.Note
 import dev.dimension.flare.data.network.misskey.api.model.NotesChildrenRequest
+import dev.dimension.flare.data.network.misskey.api.model.NotesConversationRequest
 import dev.dimension.flare.model.MicroBlogKey
 import dev.dimension.flare.ui.model.UiTimelineV2
 import dev.dimension.flare.ui.model.mapper.render
@@ -33,7 +35,7 @@ internal class StatusDetailRemoteMediator(
         pageSize: Int,
         request: PagingRequest,
     ): PagingResult<UiTimelineV2> {
-        val result =
+        val (result, nextKey) =
             when (request) {
                 is PagingRequest.Append -> {
                     if (statusOnly) {
@@ -41,14 +43,10 @@ internal class StatusDetailRemoteMediator(
                             endOfPaginationReached = true,
                         )
                     }
-                    service
-                        .notesChildren(
-                            NotesChildrenRequest(
-                                noteId = statusKey.id,
-                                untilId = request.nextKey.takeIf { it.isNotEmpty() },
-                                limit = pageSize,
-                            ),
-                        )
+                    loadReplyPage(
+                        pageSize = pageSize,
+                        untilId = request.nextKey.takeIf { it.isNotEmpty() },
+                    )
                 }
 
                 is PagingRequest.Prepend -> {
@@ -64,9 +62,18 @@ internal class StatusDetailRemoteMediator(
                                 IPinRequest(noteId = statusKey.id),
                             )
                     if (statusOnly) {
-                        listOf(current)
+                        listOf(current) to null
                     } else {
-                        listOfNotNull(current.reply, current)
+                        val ancestors =
+                            service
+                                .notesConversation(
+                                    NotesConversationRequest(
+                                        noteId = statusKey.id,
+                                        limit = MAX_CONTEXT_NOTES,
+                                    ),
+                                ).asReversed()
+                                .ifEmpty { listOfNotNull(current.reply) }
+                        (ancestors + current).distinctBy { it.id } to ""
                     }
                 }
             }
@@ -75,12 +82,64 @@ internal class StatusDetailRemoteMediator(
             endOfPaginationReached = statusOnly || result.isEmpty(),
             data =
                 result.render(accountKey),
-            nextKey =
-                if (request == PagingRequest.Refresh) {
-                    ""
-                } else {
-                    result.lastOrNull()?.id
-                },
+            nextKey = nextKey,
         )
+    }
+
+    private suspend fun loadReplyPage(
+        pageSize: Int,
+        untilId: String?,
+    ): Pair<List<Note>, String?> {
+        val limit = pageSize.coerceIn(1, MAX_CONTEXT_NOTES)
+        val directChildren =
+            service.notesChildren(
+                NotesChildrenRequest(
+                    noteId = statusKey.id,
+                    untilId = untilId,
+                    limit = limit,
+                ),
+            )
+        val result = mutableListOf<Note>()
+        val visited = mutableSetOf(statusKey.id)
+        var nestedRequests = 0
+
+        suspend fun appendChildren(
+            parentId: String,
+            children: List<Note>,
+        ) {
+            for (child in children) {
+                if (result.size >= MAX_CONTEXT_NOTES) return
+                if (!visited.add(child.id)) continue
+                result += child
+                if (
+                    result.size >= MAX_CONTEXT_NOTES ||
+                    child.replyId != parentId ||
+                    child.repliesCount <= 0 ||
+                    nestedRequests >= MAX_NESTED_CONTEXT_REQUESTS
+                ) {
+                    continue
+                }
+                nestedRequests++
+                appendChildren(
+                    parentId = child.id,
+                    children =
+                        service.notesChildren(
+                            NotesChildrenRequest(
+                                noteId = child.id,
+                                limit = minOf(limit, MAX_CONTEXT_NOTES - result.size),
+                            ),
+                        ),
+                )
+            }
+        }
+
+        // ponytail: Bound recursive API work; raise the budgets only if real threads regularly exceed them.
+        appendChildren(statusKey.id, directChildren)
+        return result to directChildren.lastOrNull()?.id
+    }
+
+    private companion object {
+        const val MAX_CONTEXT_NOTES = 100
+        const val MAX_NESTED_CONTEXT_REQUESTS = 20
     }
 }

--- a/social/misskey/src/jvmTest/kotlin/dev/dimension/flare/data/datasource/misskey/StatusDetailRemoteMediatorTest.kt
+++ b/social/misskey/src/jvmTest/kotlin/dev/dimension/flare/data/datasource/misskey/StatusDetailRemoteMediatorTest.kt
@@ -1,0 +1,77 @@
+package dev.dimension.flare.data.datasource.misskey
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import dev.dimension.flare.data.datasource.microblog.paging.PagingRequest
+import dev.dimension.flare.data.network.misskey.MisskeyService
+import dev.dimension.flare.model.MicroBlogKey
+import kotlinx.coroutines.test.runTest
+import java.net.InetSocketAddress
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StatusDetailRemoteMediatorTest {
+    @Test
+    fun loadsAncestorsAndNestedDescendantsAroundDetailPost() =
+        runTest {
+            val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+            server.createContext("/api/notes/show") { it.respond(DETAIL_JSON) }
+            server.createContext("/api/notes/conversation") { it.respond("[$PARENT_JSON,$GRANDPARENT_JSON]") }
+            server.createContext("/api/notes/children") { exchange ->
+                val body = exchange.requestBody.bufferedReader().use { it.readText() }
+                exchange.respond(
+                    when {
+                        body.contains("\"noteId\":\"detail\"") -> "[$CHILD_JSON]"
+                        body.contains("\"noteId\":\"child\"") -> "[$GRANDCHILD_JSON]"
+                        else -> "[]"
+                    },
+                )
+            }
+            server.start()
+
+            try {
+                val mediator =
+                    StatusDetailRemoteMediator(
+                        statusKey = MicroBlogKey("detail", "example.test"),
+                        accountKey = MicroBlogKey("me", "example.test"),
+                        service = MisskeyService("http://127.0.0.1:${server.address.port}/api/"),
+                        statusOnly = false,
+                    )
+
+                val refresh = mediator.load(pageSize = 20, request = PagingRequest.Refresh)
+                val append = mediator.load(pageSize = 20, request = PagingRequest.Append(refresh.nextKey.orEmpty()))
+
+                assertEquals(
+                    listOf("grandparent", "parent", "detail", "child", "grandchild"),
+                    (refresh.data + append.data).map { it.statusKey.id },
+                )
+                assertEquals("child", append.nextKey)
+            } finally {
+                server.stop(0)
+            }
+        }
+
+    private fun HttpExchange.respond(body: String) {
+        val bytes = body.encodeToByteArray()
+        responseHeaders.add("Content-Type", "application/json")
+        sendResponseHeaders(200, bytes.size.toLong())
+        responseBody.use { it.write(bytes) }
+    }
+
+    private companion object {
+        const val GRANDPARENT_JSON =
+            """{"id":"grandparent","createdAt":"2024-01-01T00:00:00Z","text":"grandparent","userId":"user","user":{"id":"user","username":"tester"},"visibility":"public","reactions":{},"renoteCount":0,"repliesCount":1}"""
+
+        const val PARENT_JSON =
+            """{"id":"parent","createdAt":"2024-01-01T00:01:00Z","text":"parent","userId":"user","user":{"id":"user","username":"tester"},"visibility":"public","reactions":{},"renoteCount":0,"repliesCount":1,"replyId":"grandparent","reply":$GRANDPARENT_JSON}"""
+
+        const val DETAIL_JSON =
+            """{"id":"detail","createdAt":"2024-01-01T00:02:00Z","text":"detail","userId":"user","user":{"id":"user","username":"tester"},"visibility":"public","reactions":{},"renoteCount":0,"repliesCount":1,"replyId":"parent","reply":$PARENT_JSON}"""
+
+        const val CHILD_JSON =
+            """{"id":"child","createdAt":"2024-01-01T00:03:00Z","text":"child","userId":"user","user":{"id":"user","username":"tester"},"visibility":"public","reactions":{},"renoteCount":0,"repliesCount":1,"replyId":"detail","reply":$DETAIL_JSON}"""
+
+        const val GRANDCHILD_JSON =
+            """{"id":"grandchild","createdAt":"2024-01-01T00:04:00Z","text":"grandchild","userId":"user","user":{"id":"user","username":"tester"},"visibility":"public","reactions":{},"renoteCount":0,"repliesCount":0,"replyId":"child","reply":$CHILD_JSON}"""
+    }
+}


### PR DESCRIPTION
## Summary

- load the full ancestor chain for Misskey/Sharkey status details via `notes/conversation`
- recursively load nested descendants while keeping pagination anchored to direct children
- bound recursive context loading and add a regression test covering ancestors, children, and grandchildren

## Testing

- `./gradlew :social:misskey:jvmTest --no-configuration-cache --console=plain`
- `./gradlew :social:misskey:compileKotlinIosSimulatorArm64 --no-configuration-cache --console=plain`
- `./gradlew :social:misskey:ktlintCommonMainSourceSetCheck :social:misskey:ktlintJvmTestSourceSetCheck --no-configuration-cache --console=plain`

Fixes #2460