### PR TITLE
fix(desktop): disable AOT cache for CPU compatibility

### DIFF
--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -131,7 +131,7 @@ nucleus.application {
     }
     nativeDistributions {
         cleanupNativeLibs = true
-        enableAotCache = true
+        enableAotCache = false
         modules("jdk.localedata")
         homepage = "https://github.com/DimensionDev/Flare"
         // Higher compression level can cause laggy for linux AppImage


### PR DESCRIPTION
## Summary

- temporarily disable Nucleus AOT cache for desktop release packages
- prevent JDK 25 AOT artifacts generated on one CPU from breaking startup on CPUs with fewer ISA features
- keep Nucleus 1.15.7 unchanged; handle the full Nucleus 2.x migration separately

## Testing

- ./gradlew :desktopApp:check --stacktrace
- ./gradlew -q :desktopApp:packageReleaseAppX --dry-run --console=plain
- ./gradlew -q :desktopApp:packageReleasePkg --dry-run --console=plain
- confirmed both release task graphs omit AOT cache generation

Fixes #2455