### PR TITLE
fix(ios): prevent profile tabs gap after navigation

### DIFF
--- a/appleApp/ios/UI/Screen/ProfileScreen.swift
+++ b/appleApp/ios/UI/Screen/ProfileScreen.swift
@@ -36,6 +36,7 @@ struct ProfileScreen: View {
             horizontalSizeClass == .compact ? Visibility.hidden : Visibility.automatic,
             for: .navigationBar
         )
+        .navigationBarTitleDisplayMode(.inline)
         .onChange(of: isBlockedProfile) { _, isBlocked in
             if !isBlocked {
                 showBlockedProfileContent = false


### PR DESCRIPTION
## Summary

- Force `ProfileScreen` to use inline navigation titles.
- Prevent the profile tabs from inheriting an empty large-title navigation-bar region after returning from a detail screen.

## Verification

- `xcodebuild -project appleApp/Flare.xcodeproj -scheme iOS -configuration Debug -destination 'platform=iOS Simulator,id=DB181985-4CE3-4154-9210-65874F6F0278' -derivedDataPath /tmp/flare-profile-gap-derived-data -skipPackagePluginValidation -skipMacroValidation build`
- Reproduced the original flow on an iPhone 15 Pro / iOS 27 simulator: enter Profile from a large-title navigation path, pin the tabs, open a status detail, then navigate back.
- The tab indicator remained at the baseline position (`y=234`) instead of shifting down by 52 pt.