### PR TITLE
perf(timeline): reduce native hydration and UIKit paging overhead

### DIFF
--- a/appleApp/Shared/FlareAppleCore/Sources/FlareAppleUI/RichText.swift
+++ b/appleApp/Shared/FlareAppleCore/Sources/FlareAppleUI/RichText.swift
@@ -15,6 +15,7 @@ private typealias PlatformImage = NSImage
 
 public struct RichText: View {
     private let text: UiRichText
+    private let contents: [PlatformTextContent]
     @State private var images: [String: Image] = [:]
     @ScaledMetric(relativeTo: .body) private var imageSize = 17
     @ScaledMetric(relativeTo: .body) private var quoteBarWidth = 3
@@ -22,6 +23,7 @@ public struct RichText: View {
 
     public init(text: UiRichText) {
         self.text = text
+        self.contents = text.platformText.compactMap { $0 as? PlatformTextContent }
     }
 
     public var body: some View {
@@ -65,10 +67,6 @@ public struct RichText: View {
                 }
             }
         }
-    }
-
-    private var contents: [PlatformTextContent] {
-        text.platformText.compactMap { $0 as? PlatformTextContent }
     }
 
     @ViewBuilder

--- a/appleApp/ios/UI/Component/CollectionViewTimeline.swift
+++ b/appleApp/ios/UI/Component/CollectionViewTimeline.swift
@@ -6,6 +6,180 @@ import CHTCollectionViewWaterfallLayout
 import GSPlayer
 import AVFoundation
 
+/// Swift-owned mirror of Kotlin's lightweight paging metadata.
+/// Incremental transitions only cross the Kotlin/Native boundary for changed items.
+struct PagingUIKitPresentationState: Sendable {
+    let revision: Int64
+    let itemIDs: [String]
+    let indexMap: [String: Int]
+    let renderHashMap: [String: Int32]
+    let loadedItemIDs: Set<String>
+
+    init?(
+        snapshot: PagingPresentationSnapshot,
+        itemPrefix: String,
+        placeholderPrefix: String
+    ) {
+        let count = Int(snapshot.itemCount)
+        var itemIDs: [String] = []
+        var indexMap: [String: Int] = [:]
+        var renderHashMap: [String: Int32] = [:]
+        var loadedItemIDs = Set<String>()
+        itemIDs.reserveCapacity(count)
+
+        for index in 0..<count {
+            guard let item = snapshot.itemAt(index: Int32(index)) else { return nil }
+            let resolved = Self.resolveItem(
+                item,
+                index: index,
+                itemPrefix: itemPrefix,
+                placeholderPrefix: placeholderPrefix
+            )
+            guard indexMap[resolved.id] == nil else { return nil }
+            itemIDs.append(resolved.id)
+            indexMap[resolved.id] = index
+            if resolved.isLoaded {
+                renderHashMap[resolved.id] = item.renderHash
+                loadedItemIDs.insert(resolved.id)
+            }
+        }
+
+        self.revision = snapshot.revision
+        self.itemIDs = itemIDs
+        self.indexMap = indexMap
+        self.renderHashMap = renderHashMap
+        self.loadedItemIDs = loadedItemIDs
+    }
+
+    func transition(
+        to snapshot: PagingPresentationSnapshot,
+        itemPrefix: String,
+        placeholderPrefix: String
+    ) -> PagingUIKitPresentationTransition? {
+        guard snapshot.revision != revision else {
+            return PagingUIKitPresentationTransition(
+                state: self,
+                structureChanged: false,
+                reconfiguredItemIDs: []
+            )
+        }
+        guard let change = snapshot.change,
+              change.baseRevision == revision,
+              change.revision == snapshot.revision else {
+            return nil
+        }
+
+        var nextItemIDs = itemIDs
+        var nextRenderHashMap = renderHashMap
+        var nextLoadedItemIDs = loadedItemIDs
+        var structureChanged = false
+
+        if let replacement = change.replacement {
+            // Placeholder identities are position-based. Rebuild if a structural change could
+            // shift them; timeline paging currently disables placeholders, so this is a fallback.
+            guard !itemIDs.contains(where: { $0.hasPrefix(placeholderPrefix) }) else { return nil }
+            let start = Int(replacement.startIndex)
+            let removeCount = Int(replacement.removeCount)
+            guard start >= 0,
+                  removeCount >= 0,
+                  start <= nextItemIDs.count,
+                  start + removeCount <= nextItemIDs.count else {
+                return nil
+            }
+
+            var insertedIDs: [String] = []
+            var insertedHashes: [String: Int32] = [:]
+            insertedIDs.reserveCapacity(Int(replacement.insertedCount))
+            for offset in 0..<Int(replacement.insertedCount) {
+                guard let item = replacement.insertedItemAt(index: Int32(offset)) else { return nil }
+                let resolved = Self.resolveItem(
+                    item,
+                    index: start + offset,
+                    itemPrefix: itemPrefix,
+                    placeholderPrefix: placeholderPrefix
+                )
+                guard resolved.isLoaded else { return nil }
+                insertedIDs.append(resolved.id)
+                insertedHashes[resolved.id] = item.renderHash
+            }
+
+            let removedIDs = Array(nextItemIDs[start..<(start + removeCount)])
+            nextItemIDs.replaceSubrange(start..<(start + removeCount), with: insertedIDs)
+            guard Set(nextItemIDs).count == nextItemIDs.count else { return nil }
+            removedIDs.forEach {
+                nextRenderHashMap.removeValue(forKey: $0)
+                nextLoadedItemIDs.remove($0)
+            }
+            insertedIDs.forEach {
+                nextRenderHashMap[$0] = insertedHashes[$0]
+                nextLoadedItemIDs.insert($0)
+            }
+            structureChanged = true
+        }
+
+        guard nextItemIDs.count == Int(snapshot.itemCount) else { return nil }
+        let nextIndexMap = Dictionary(uniqueKeysWithValues: nextItemIDs.enumerated().map { ($1, $0) })
+        var reconfiguredItemIDs: [String] = []
+        reconfiguredItemIDs.reserveCapacity(Int(change.reloadedCount))
+        for offset in 0..<Int(change.reloadedCount) {
+            guard let item = change.reloadedItemAt(index: Int32(offset)),
+                  let key = item.key,
+                  !key.isEmpty else {
+                continue
+            }
+            let id = "\(itemPrefix)\(key)"
+            guard nextIndexMap[id] != nil else { return nil }
+            nextRenderHashMap[id] = item.renderHash
+            nextLoadedItemIDs.insert(id)
+            reconfiguredItemIDs.append(id)
+        }
+
+        return PagingUIKitPresentationTransition(
+            state: PagingUIKitPresentationState(
+                revision: snapshot.revision,
+                itemIDs: nextItemIDs,
+                indexMap: nextIndexMap,
+                renderHashMap: nextRenderHashMap,
+                loadedItemIDs: nextLoadedItemIDs
+            ),
+            structureChanged: structureChanged,
+            reconfiguredItemIDs: reconfiguredItemIDs
+        )
+    }
+
+    private init(
+        revision: Int64,
+        itemIDs: [String],
+        indexMap: [String: Int],
+        renderHashMap: [String: Int32],
+        loadedItemIDs: Set<String>
+    ) {
+        self.revision = revision
+        self.itemIDs = itemIDs
+        self.indexMap = indexMap
+        self.renderHashMap = renderHashMap
+        self.loadedItemIDs = loadedItemIDs
+    }
+
+    private static func resolveItem(
+        _ item: PagingPresentationItem,
+        index: Int,
+        itemPrefix: String,
+        placeholderPrefix: String
+    ) -> (id: String, isLoaded: Bool) {
+        if let key = item.key, !key.isEmpty {
+            return ("\(itemPrefix)\(key)", true)
+        }
+        return ("\(placeholderPrefix)\(index)", false)
+    }
+}
+
+struct PagingUIKitPresentationTransition: Sendable {
+    let state: PagingUIKitPresentationState
+    let structureChanged: Bool
+    let reconfiguredItemIDs: [String]
+}
+
 enum TimelineUIKitLayoutMetrics {
     static let horizontalInset: CGFloat = 16
     static let columnSpacing: CGFloat = 8
@@ -320,6 +494,7 @@ final class UITimelineCollectionViewController: UIViewController, UICollectionVi
     private var lastAppliedSignature: SnapshotSignature?
     private var lastRenderHashMap: [String: Int32] = [:]
     private var lastLoadedItemIDs: Set<String> = []
+    private var lastPagingPresentation: PagingUIKitPresentationState?
     private let autoplayPlayerView = VideoPlayerView()
     private var autoplayPlayerObservation: NSKeyValueObservation?
     private var autoplaySelectionTask: Task<Void, Never>?
@@ -358,6 +533,8 @@ final class UITimelineCollectionViewController: UIViewController, UICollectionVi
         let loadedItemIDs: Set<String>
         let isRefreshing: Bool
         let isInitialLoading: Bool
+        let pagingPresentation: PagingUIKitPresentationState?
+        let knownChangedItemIDs: [String]?
     }
 
     private struct ScrollAnchor {
@@ -1149,6 +1326,7 @@ final class UITimelineCollectionViewController: UIViewController, UICollectionVi
         currentSuccess = nil
         currentProfileMediaData = nil
         currentProfileMediaSuccess = nil
+        lastPagingPresentation = nil
         pendingScrollAnchor = nil
         lastProfileMediaScrollAnchor = nil
         profileMediaGeometryTransition = nil
@@ -1370,6 +1548,7 @@ final class UITimelineCollectionViewController: UIViewController, UICollectionVi
             lastAppliedSignature = plan.signature
             lastRenderHashMap = plan.renderHashMap
             lastLoadedItemIDs = plan.loadedItemIDs
+            lastPagingPresentation = plan.pagingPresentation
             CATransaction.commit()
         }
     }
@@ -1388,11 +1567,66 @@ final class UITimelineCollectionViewController: UIViewController, UICollectionVi
     }
 
     private func applySnapshot(data: PagingState<UiTimelineV2>) {
+        if applyPagingPresentationUpdate(data: data) {
+            return
+        }
         applySnapshot(plan: makeSnapshotPlan(data: data, columnCount: columnCount))
     }
 
     private func applySnapshot(profileMediaData data: PagingState<ProfileMedia>) {
         applySnapshot(plan: makeSnapshotPlan(profileMediaData: data, columnCount: columnCount))
+    }
+
+    private func applyPagingPresentationUpdate(data: PagingState<UiTimelineV2>) -> Bool {
+        guard contentKind == .timeline,
+              case .success(let success) = onEnum(of: data),
+              let snapshot = success.pagingPresentation,
+              let previousPresentation = lastPagingPresentation,
+              let previousSignature = lastAppliedSignature else {
+            return false
+        }
+        let accessoryIDs = accessoryItems.map { "\(Self.accessoryPrefix)\($0.id)" }
+        guard previousSignature.accessoryIDs == accessoryIDs,
+              let transition = previousPresentation.transition(
+                  to: snapshot,
+                  itemPrefix: Self.timelinePrefix,
+                  placeholderPrefix: Self.placeholderPrefix
+              ) else {
+            return false
+        }
+
+        let plan = makeSnapshotPlan(
+            data: data,
+            success: success,
+            presentation: transition.state,
+            knownChangedItemIDs: transition.reconfiguredItemIDs
+        )
+        guard !transition.structureChanged,
+              previousSignature.itemIDs == plan.itemIDs else {
+            applySnapshot(plan: plan)
+            return true
+        }
+
+        // Content and load-state-only changes do not need a rebuilt diffable snapshot.
+        snapshotPreparationGeneration += 1
+        itemIndexMap = plan.indexMap
+        lastRenderHashMap = plan.renderHashMap
+        lastLoadedItemIDs = plan.loadedItemIDs
+        lastPagingPresentation = plan.pagingPresentation
+        if previousSignature.footerIDs != plan.footerIDs {
+            applyFooterSnapshot(
+                footerIDs: plan.footerIDs,
+                reconfigureIDs: transition.reconfiguredItemIDs,
+                isRefreshing: plan.isRefreshing
+            )
+        } else {
+            reconfigureItems(transition.reconfiguredItemIDs)
+        }
+        lastAppliedSignature = plan.signature
+        restorePendingContentOffsetIfNeeded(finalize: true)
+        validateCurrentAutoplayVisibility()
+        scheduleAutoplaySelection()
+        return true
     }
 
     private func applySnapshot(plan: SnapshotPlan) {
@@ -1411,7 +1645,21 @@ final class UITimelineCollectionViewController: UIViewController, UICollectionVi
         data: PagingState<UiTimelineV2>,
         columnCount: Int
     ) -> SnapshotPlan {
-        makeSnapshotPlan(
+        if case .success(let success) = onEnum(of: data),
+           let presentation = success.pagingPresentation,
+           let presentationState = PagingUIKitPresentationState(
+               snapshot: presentation,
+               itemPrefix: Self.timelinePrefix,
+               placeholderPrefix: Self.placeholderPrefix
+           ) {
+            return makeSnapshotPlan(
+                data: data,
+                success: success,
+                presentation: presentationState,
+                knownChangedItemIDs: nil
+            )
+        }
+        return makeSnapshotPlan(
             data: data,
             loadingItemCount: loadingPlaceholderCount(
                 minimum: TimelineUIKitLayoutMetrics.timelinePlaceholderCount,
@@ -1506,7 +1754,36 @@ final class UITimelineCollectionViewController: UIViewController, UICollectionVi
             renderHashMap: newRenderHashMap,
             loadedItemIDs: newLoadedItemIDs,
             isRefreshing: pagingIsRefreshing(data),
-            isInitialLoading: isInitialLoading
+            isInitialLoading: isInitialLoading,
+            pagingPresentation: nil,
+            knownChangedItemIDs: nil
+        )
+    }
+
+    private func makeSnapshotPlan(
+        data: PagingState<UiTimelineV2>,
+        success: PagingStateSuccess<UiTimelineV2>,
+        presentation: PagingUIKitPresentationState,
+        knownChangedItemIDs: [String]?
+    ) -> SnapshotPlan {
+        let accessoryIDs = accessoryItems.map { "\(Self.accessoryPrefix)\($0.id)" }
+        let footerIDs = footerItemIDs(for: success)
+        return SnapshotPlan(
+            signature: SnapshotSignature(
+                accessoryIDs: accessoryIDs,
+                itemIDs: presentation.itemIDs,
+                footerIDs: footerIDs
+            ),
+            accessoryIDs: accessoryIDs,
+            itemIDs: presentation.itemIDs,
+            footerIDs: footerIDs,
+            indexMap: presentation.indexMap,
+            renderHashMap: presentation.renderHashMap,
+            loadedItemIDs: presentation.loadedItemIDs,
+            isRefreshing: pagingIsRefreshing(data),
+            isInitialLoading: false,
+            pagingPresentation: presentation,
+            knownChangedItemIDs: knownChangedItemIDs
         )
     }
 
@@ -1573,13 +1850,14 @@ final class UITimelineCollectionViewController: UIViewController, UICollectionVi
         if previousSignature?.accessoryIDs == newSignature.accessoryIDs,
            previousSignature?.itemIDs == newSignature.itemIDs,
            previousSignature?.footerIDs == newSignature.footerIDs {
-            let changedIDs = changedItemIDs(
+            let changedIDs = plan.knownChangedItemIDs ?? changedItemIDs(
                 in: plan.itemIDs,
                 newRenderHashMap: plan.renderHashMap,
                 newLoadedItemIDs: plan.loadedItemIDs
             )
             lastRenderHashMap = plan.renderHashMap
             lastLoadedItemIDs = plan.loadedItemIDs
+            lastPagingPresentation = plan.pagingPresentation
             reconfigureItems(changedIDs)
             restorePendingContentOffsetIfNeeded(finalize: !plan.isInitialLoading)
             validateCurrentAutoplayVisibility()
@@ -1589,7 +1867,7 @@ final class UITimelineCollectionViewController: UIViewController, UICollectionVi
 
         if previousSignature?.accessoryIDs == newSignature.accessoryIDs,
            previousSignature?.itemIDs == newSignature.itemIDs {
-            let changedIDs = changedItemIDs(
+            let changedIDs = plan.knownChangedItemIDs ?? changedItemIDs(
                 in: plan.itemIDs,
                 newRenderHashMap: plan.renderHashMap,
                 newLoadedItemIDs: plan.loadedItemIDs
@@ -1599,6 +1877,7 @@ final class UITimelineCollectionViewController: UIViewController, UICollectionVi
             lastAppliedSignature = newSignature
             lastRenderHashMap = plan.renderHashMap
             lastLoadedItemIDs = plan.loadedItemIDs
+            lastPagingPresentation = plan.pagingPresentation
             validateCurrentAutoplayVisibility()
             scheduleAutoplaySelection()
             return
@@ -1606,13 +1885,15 @@ final class UITimelineCollectionViewController: UIViewController, UICollectionVi
 
         // Reconfigure only existing timeline items whose render payload or loaded state changed.
         let existing = Set(dataSource.snapshot().itemIdentifiers)
-        let toReconfigure = plan.itemIDs.filter {
-            existing.contains($0) && itemNeedsReconfigure(
-                $0,
-                newRenderHashMap: plan.renderHashMap,
-                newLoadedItemIDs: plan.loadedItemIDs
-            )
-        }
+        let toReconfigure =
+            plan.knownChangedItemIDs?.filter(existing.contains) ??
+            plan.itemIDs.filter {
+                existing.contains($0) && itemNeedsReconfigure(
+                    $0,
+                    newRenderHashMap: plan.renderHashMap,
+                    newLoadedItemIDs: plan.loadedItemIDs
+                )
+            }
         if !toReconfigure.isEmpty {
             snapshot.reconfigureItems(toReconfigure)
         }
@@ -1653,6 +1934,7 @@ final class UITimelineCollectionViewController: UIViewController, UICollectionVi
         lastAppliedSignature = newSignature
         lastRenderHashMap = plan.renderHashMap
         lastLoadedItemIDs = plan.loadedItemIDs
+        lastPagingPresentation = plan.pagingPresentation
     }
 
     private func changedItemIDs(

--- a/appleApp/ios/UI/Component/GalleryTimelinePagingView.swift
+++ b/appleApp/ios/UI/Component/GalleryTimelinePagingView.swift
@@ -83,6 +83,7 @@ final class UIGalleryTimelineController: UIViewController, UICollectionViewDeleg
     private var lastAppliedSignature: SnapshotSignature?
     private var lastRenderHashMap: [String: Int32] = [:]
     private var lastLoadedItemIDs: Set<String> = []
+    private var lastPagingPresentation: PagingUIKitPresentationState?
     private var lastProcessedDataRef: AnyObject?
     private var lastProcessedUpdateSignature: UpdateSignature?
 
@@ -136,6 +137,11 @@ final class UIGalleryTimelineController: UIViewController, UICollectionViewDeleg
         case loading
         case error
         case empty
+        case pagingPresentation(
+            revision: Int64,
+            isRefreshing: Bool,
+            footerIDs: [String]
+        )
         case success(
             itemIDs: [String],
             renderHashMap: [String: Int32],
@@ -331,6 +337,13 @@ final class UIGalleryTimelineController: UIViewController, UICollectionViewDeleg
         case .empty:
             return .empty
         case .success(let success):
+            if let presentation = success.pagingPresentation {
+                return .pagingPresentation(
+                    revision: presentation.revision,
+                    isRefreshing: success.isRefreshing,
+                    footerIDs: footerItemIDs(for: success)
+                )
+            }
             let itemState = makeItemSnapshotState(for: success)
             return .success(
                 itemIDs: itemState.itemIDs,
@@ -381,6 +394,17 @@ final class UIGalleryTimelineController: UIViewController, UICollectionViewDeleg
             indexMap: indexMap,
             renderHashMap: renderHashMap,
             loadedItemIDs: loadedItemIDs
+        )
+    }
+
+    private func makeItemSnapshotState(
+        for presentation: PagingUIKitPresentationState
+    ) -> ItemSnapshotState {
+        ItemSnapshotState(
+            itemIDs: presentation.itemIDs,
+            indexMap: presentation.indexMap,
+            renderHashMap: presentation.renderHashMap,
+            loadedItemIDs: presentation.loadedItemIDs
         )
     }
 
@@ -499,24 +523,49 @@ final class UIGalleryTimelineController: UIViewController, UICollectionViewDeleg
         var newLoadedItemIDs = Set<String>()
         var itemIDs: [String] = []
         var footerIDs: [String] = []
+        var knownChangedItemIDs: [String]?
 
         switch onEnum(of: data) {
         case .loading:
+            lastPagingPresentation = nil
             snapshot.appendSections([Self.sectionMain])
             let items = (0..<8).map { "\(Self.placeholderPrefix)\($0)" }
             itemIDs = items
             snapshot.appendItems(itemIDs, toSection: Self.sectionMain)
         case .error:
+            lastPagingPresentation = nil
             snapshot.appendSections([Self.sectionMain])
             itemIDs = [Self.errorID]
             snapshot.appendItems(itemIDs, toSection: Self.sectionMain)
         case .empty:
+            lastPagingPresentation = nil
             snapshot.appendSections([Self.sectionMain])
             itemIDs = [Self.emptyID]
             snapshot.appendItems(itemIDs, toSection: Self.sectionMain)
         case .success(let success):
             snapshot.appendSections([Self.sectionMain])
-            let itemState = makeItemSnapshotState(for: success)
+            let itemState: ItemSnapshotState
+            if let presentation = success.pagingPresentation,
+               let transition = lastPagingPresentation?.transition(
+                   to: presentation,
+                   itemPrefix: Self.itemPrefix,
+                   placeholderPrefix: Self.placeholderPrefix
+               ) {
+                lastPagingPresentation = transition.state
+                knownChangedItemIDs = transition.reconfiguredItemIDs
+                itemState = makeItemSnapshotState(for: transition.state)
+            } else if let presentation = success.pagingPresentation,
+                      let presentationState = PagingUIKitPresentationState(
+                          snapshot: presentation,
+                          itemPrefix: Self.itemPrefix,
+                          placeholderPrefix: Self.placeholderPrefix
+                      ) {
+                lastPagingPresentation = presentationState
+                itemState = makeItemSnapshotState(for: presentationState)
+            } else {
+                lastPagingPresentation = nil
+                itemState = makeItemSnapshotState(for: success)
+            }
             itemIDs = itemState.itemIDs
             newIndexMap = itemState.indexMap
             newRenderHashMap = itemState.renderHashMap
@@ -543,7 +592,7 @@ final class UIGalleryTimelineController: UIViewController, UICollectionViewDeleg
         pruneHeightCache(keepingItemIDs: Set(newIndexMap.keys))
 
         if previousSignature == newSignature {
-            let changedIDs = changedItemIDs(
+            let changedIDs = knownChangedItemIDs ?? changedItemIDs(
                 in: itemIDs,
                 newRenderHashMap: newRenderHashMap,
                 newLoadedItemIDs: newLoadedItemIDs
@@ -555,7 +604,7 @@ final class UIGalleryTimelineController: UIViewController, UICollectionViewDeleg
         }
 
         if previousSignature?.itemIDs == newSignature.itemIDs {
-            let changedIDs = changedItemIDs(
+            let changedIDs = knownChangedItemIDs ?? changedItemIDs(
                 in: itemIDs,
                 newRenderHashMap: newRenderHashMap,
                 newLoadedItemIDs: newLoadedItemIDs
@@ -569,13 +618,14 @@ final class UIGalleryTimelineController: UIViewController, UICollectionViewDeleg
 
         let existing = dataSource.snapshot().itemIdentifiers
         let newSet = Set(snapshot.itemIdentifiers)
-        let toReconfigure = existing.filter {
-            newSet.contains($0) && itemNeedsReconfigure(
-                $0,
-                newRenderHashMap: newRenderHashMap,
-                newLoadedItemIDs: newLoadedItemIDs
-            )
-        }
+        let toReconfigure = knownChangedItemIDs?.filter { newSet.contains($0) } ??
+            existing.filter {
+                newSet.contains($0) && itemNeedsReconfigure(
+                    $0,
+                    newRenderHashMap: newRenderHashMap,
+                    newLoadedItemIDs: newLoadedItemIDs
+                )
+            }
         if !toReconfigure.isEmpty {
             snapshot.reconfigureItems(toReconfigure)
         }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -30,6 +30,7 @@ kotlin {
         )
     }
     android {
+        withHostTest {}
         withDeviceTest {
             instrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
             execution = "HOST"
@@ -105,6 +106,13 @@ kotlin {
                 implementation(libs.kotlinx.coroutines.test)
             }
         }
+        val androidHostTest by getting {
+            dependencies {
+                implementation(libs.junit)
+                implementation(libs.robolectric)
+                implementation(libs.kotlinx.coroutines.test)
+            }
+        }
         val jvmMain by getting {
             dependencies {
                 implementation(libs.commons.lang3)
@@ -130,4 +138,68 @@ kotlin {
 
 room3 {
     schemaDirectory("$projectDir/schemas")
+}
+
+val runDatabaseBenchmark =
+    providers
+        .gradleProperty("runDatabaseBenchmark")
+        .map(String::toBoolean)
+        .orElse(false)
+
+tasks.withType<org.gradle.api.tasks.testing.AbstractTestTask>().configureEach {
+    if (runDatabaseBenchmark.get()) {
+        outputs.upToDateWhen { false }
+        testLogging.showStandardStreams = true
+    } else {
+        filter.excludeTestsMatching("*TimelineDatabaseBenchmarkTest*")
+    }
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest>().configureEach {
+    if (runDatabaseBenchmark.get()) {
+        environment("FLARE_RUN_DATABASE_BENCHMARK", "true")
+    }
+}
+
+val sqliteBundledJvmNative = configurations.create("sqliteBundledJvmNative")
+dependencies.add(
+    sqliteBundledJvmNative.name,
+    "androidx.sqlite:sqlite-bundled-jvm:${libs.versions.sqlite.get()}",
+)
+
+val sqliteNativeLibrary =
+    when {
+        System.getProperty("os.name").startsWith("Mac") && System.getProperty("os.arch") in setOf("aarch64", "arm64") ->
+            "natives/osx_arm64" to "libsqliteJni.dylib"
+        System.getProperty("os.name").startsWith("Linux") && System.getProperty("os.arch") in setOf("aarch64", "arm64") ->
+            "natives/linux_arm64" to "libsqliteJni.so"
+        System.getProperty("os.name").startsWith("Linux") ->
+            "natives/linux_x64" to "libsqliteJni.so"
+        System.getProperty("os.name").startsWith("Windows") ->
+            "natives/windows_x64" to "sqliteJni.dll"
+        else -> null
+    }
+
+if (sqliteNativeLibrary != null) {
+    val extractSqliteBundledJvmNative =
+        tasks.register<org.gradle.api.tasks.Sync>("extractSqliteBundledJvmNative") {
+            from({ sqliteBundledJvmNative.files.map(::zipTree) }) {
+                include("${sqliteNativeLibrary.first}/${sqliteNativeLibrary.second}")
+            }
+            into(layout.buildDirectory.dir("sqlite-bundled-jvm-native"))
+        }
+
+    tasks.withType<org.gradle.api.tasks.testing.Test>().configureEach {
+        if (name == "testAndroidHostTest") {
+            dependsOn(extractSqliteBundledJvmNative)
+            systemProperty(
+                "androidx.sqlite.driver.bundled.path",
+                layout.buildDirectory
+                    .dir("sqlite-bundled-jvm-native/${sqliteNativeLibrary.first}")
+                    .get()
+                    .asFile.absolutePath,
+            )
+            systemProperty("androidx.sqlite.driver.bundled.name", sqliteNativeLibrary.second)
+        }
+    }
 }

--- a/shared/karma.config.d/database-benchmark-timeout.js
+++ b/shared/karma.config.d/database-benchmark-timeout.js
@@ -1,0 +1,9 @@
+if (process.env.FLARE_RUN_DATABASE_BENCHMARK === "true") {
+    config.set({
+        client: {
+            mocha: {
+                timeout: 300000,
+            },
+        },
+    });
+}

--- a/shared/src/androidHostTest/kotlin/dev/dimension/flare/DatabaseHelper.android.kt
+++ b/shared/src/androidHostTest/kotlin/dev/dimension/flare/DatabaseHelper.android.kt
@@ -3,16 +3,23 @@ package dev.dimension.flare
 import androidx.room3.Room
 import androidx.room3.RoomDatabase
 import androidx.test.platform.app.InstrumentationRegistry
+import dev.dimension.flare.data.database.cache.CacheDatabase
+import dev.dimension.flare.data.database.cache.TimelineDependencyRevisionCallback
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import kotlin.test.Ignore
 import kotlin.reflect.KClass
+import kotlin.test.Ignore
 
 internal actual fun <T : RoomDatabase> Room.memoryDatabaseBuilder(databaseClass: KClass<T>): RoomDatabase.Builder<T> =
-    Room.inMemoryDatabaseBuilder(
-        InstrumentationRegistry.getInstrumentation().context,
-        databaseClass.java,
-    )
+    Room
+        .inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().context,
+            databaseClass.java,
+        ).apply {
+            if (databaseClass == CacheDatabase::class) {
+                addCallback(TimelineDependencyRevisionCallback)
+            }
+        }
 
 @RunWith(RobolectricTestRunner::class)
 @Ignore

--- a/shared/src/androidHostTest/kotlin/dev/dimension/flare/TestFileHelper.android.kt
+++ b/shared/src/androidHostTest/kotlin/dev/dimension/flare/TestFileHelper.android.kt
@@ -1,0 +1,34 @@
+package dev.dimension.flare
+
+import dev.dimension.flare.common.FileItem
+import dev.dimension.flare.common.FileType
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+import java.io.File
+import java.nio.file.Files
+import kotlin.uuid.Uuid
+
+internal actual fun createTestRootPath(): Path = Files.createTempDirectory("draft-media-store-test").toString().toPath()
+
+internal actual fun deleteTestRootPath(path: Path) {
+    File(path.toString()).deleteRecursively()
+}
+
+internal actual fun createTestFileSystem(): FileSystem = FileSystem.SYSTEM
+
+internal actual fun createTestFileItem(
+    root: Path,
+    name: String?,
+    bytes: ByteArray,
+    type: FileType,
+): FileItem {
+    val file = File(root.toString(), "source_${Uuid.random()}.bin")
+    file.parentFile?.mkdirs()
+    file.writeBytes(bytes)
+    return FileItem(
+        name = name,
+        type = type,
+        source = FileItem.Source.PathSource(file.path),
+    )
+}

--- a/shared/src/androidHostTest/kotlin/dev/dimension/flare/benchmark/BenchmarkRuntime.android.kt
+++ b/shared/src/androidHostTest/kotlin/dev/dimension/flare/benchmark/BenchmarkRuntime.android.kt
@@ -1,0 +1,9 @@
+package dev.dimension.flare.benchmark
+
+internal actual val benchmarkPlatform: String = "android-robolectric-bundled-sqlite"
+
+internal actual fun collectLiveHeapBytes(): Long? {
+    System.gc()
+    val runtime = Runtime.getRuntime()
+    return runtime.totalMemory() - runtime.freeMemory()
+}

--- a/shared/src/appleTest/kotlin/dev/dimension/flare/DatabaseHelper.apple.kt
+++ b/shared/src/appleTest/kotlin/dev/dimension/flare/DatabaseHelper.apple.kt
@@ -4,14 +4,25 @@ import androidx.room3.Room
 import androidx.room3.RoomDatabase
 import dev.dimension.flare.data.database.app.AppDatabase
 import dev.dimension.flare.data.database.cache.CacheDatabase
+import dev.dimension.flare.data.database.cache.TimelineDependencyRevisionCallback
 import kotlin.reflect.KClass
 
 @Suppress("UNCHECKED_CAST")
 internal actual fun <T : RoomDatabase> Room.memoryDatabaseBuilder(databaseClass: KClass<T>): RoomDatabase.Builder<T> =
     when (databaseClass) {
-        AppDatabase::class -> Room.inMemoryDatabaseBuilder<AppDatabase>()
-        CacheDatabase::class -> Room.inMemoryDatabaseBuilder<CacheDatabase>()
-        else -> error("Unsupported test database: ${databaseClass.qualifiedName}")
+        AppDatabase::class -> {
+            Room.inMemoryDatabaseBuilder<AppDatabase>()
+        }
+
+        CacheDatabase::class -> {
+            Room
+                .inMemoryDatabaseBuilder<CacheDatabase>()
+                .addCallback(TimelineDependencyRevisionCallback)
+        }
+
+        else -> {
+            error("Unsupported test database: ${databaseClass.qualifiedName}")
+        }
     } as RoomDatabase.Builder<T>
 
 actual open class RobolectricTest actual constructor()

--- a/shared/src/appleTest/kotlin/dev/dimension/flare/benchmark/BenchmarkRuntime.apple.kt
+++ b/shared/src/appleTest/kotlin/dev/dimension/flare/benchmark/BenchmarkRuntime.apple.kt
@@ -1,0 +1,23 @@
+@file:OptIn(
+    ExperimentalStdlibApi::class,
+    kotlin.experimental.ExperimentalNativeApi::class,
+    kotlin.native.runtime.NativeRuntimeApi::class,
+)
+
+package dev.dimension.flare.benchmark
+
+import kotlin.native.Platform
+import kotlin.native.runtime.GC
+
+internal actual val benchmarkPlatform: String =
+    "${Platform.osFamily.name.lowercase()}-${Platform.cpuArchitecture.name.lowercase()}-" +
+        (if (Platform.isDebugBinary) "debug" else "release") +
+        "-bundled-sqlite"
+
+internal actual fun collectLiveHeapBytes(): Long? {
+    GC.collect()
+    return GC.lastGCInfo
+        ?.memoryUsageAfter
+        ?.get("heap")
+        ?.totalObjectsSizeBytes
+}

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/common/PagingPresentation.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/common/PagingPresentation.kt
@@ -1,0 +1,448 @@
+package dev.dimension.flare.common
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.paging.CombinedLoadStates
+import androidx.paging.ItemSnapshotList
+import androidx.paging.LoadState
+import androidx.paging.LoadStates
+import androidx.paging.PagingData
+import androidx.paging.PagingDataEvent
+import androidx.paging.PagingDataPresenter
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+
+/** Lightweight item information used by non-Compose paging front ends. */
+@Immutable
+public data class PagingPresentationItem internal constructor(
+    public val key: String?,
+    public val renderHash: Int,
+)
+
+/** A single contiguous replacement that transforms one presented list into the next. */
+@Immutable
+public class PagingPresentationReplacement internal constructor(
+    public val startIndex: Int,
+    public val removeCount: Int,
+    private val insertedItems: List<PagingPresentationItem>,
+) {
+    public val insertedCount: Int
+        get() = insertedItems.size
+
+    public fun insertedItemAt(index: Int): PagingPresentationItem? = insertedItems.getOrNull(index)
+}
+
+/** Changes between two consecutive [PagingPresentationSnapshot] revisions. */
+@Immutable
+public class PagingPresentationChange internal constructor(
+    public val baseRevision: Long,
+    public val revision: Long,
+    public val replacement: PagingPresentationReplacement?,
+    private val reloadedItems: List<PagingPresentationItem>,
+) {
+    public val reloadedCount: Int
+        get() = reloadedItems.size
+
+    public fun reloadedItemAt(index: Int): PagingPresentationItem? = reloadedItems.getOrNull(index)
+}
+
+/**
+ * Versioned, lightweight mirror of the list presented by Paging.
+ *
+ * UIKit normally consumes [change]. If it misses a revision it can rebuild from this snapshot
+ * without traversing the full Kotlin object graph through [PagingState.Success.peek].
+ */
+@Immutable
+public class PagingPresentationSnapshot internal constructor(
+    public val revision: Long,
+    private val presentedItems: List<PagingPresentationItem>,
+    public val change: PagingPresentationChange?,
+) {
+    public val itemCount: Int
+        get() = presentedItems.size
+
+    public fun itemAt(index: Int): PagingPresentationItem? = presentedItems.getOrNull(index)
+}
+
+internal fun interface PagingPresentationMapper<T : Any> {
+    fun map(item: T): PagingPresentationItem
+}
+
+/**
+ * Paging front end that retains the existing get/peek/load-state behavior while also exposing
+ * [PagingDataEvent] as a versioned presentation change set.
+ */
+@Stable
+internal class EventAwarePagingItems<T : Any>(
+    private val flow: Flow<PagingData<T>>,
+    private val mapper: PagingPresentationMapper<T>,
+) {
+    private val pagingDataPresenter =
+        object :
+            PagingDataPresenter<T>(
+                cachedPagingData =
+                    if (flow is SharedFlow<PagingData<T>>) {
+                        flow.replayCache.firstOrNull()
+                    } else {
+                        null
+                    },
+            ) {
+            override suspend fun presentPagingDataEvent(event: PagingDataEvent<T>) {
+                updateItems(event)
+            }
+        }
+
+    private val initialItems = pagingDataPresenter.snapshot()
+    private val presentationTracker =
+        PagingPresentationTracker(
+            initialItems = initialItems.toPresentationItems(mapper),
+        )
+
+    var itemState: EventAwarePagingItemState<T> by
+        mutableStateOf(
+            EventAwarePagingItemState(
+                items = initialItems,
+                presentation = presentationTracker.snapshot,
+            ),
+        )
+        private set
+
+    var loadState: CombinedLoadStates by
+        mutableStateOf(
+            pagingDataPresenter.loadStateFlow.value
+                ?: CombinedLoadStates(
+                    refresh = InitialEventAwareLoadStates.refresh,
+                    prepend = InitialEventAwareLoadStates.prepend,
+                    append = InitialEventAwareLoadStates.append,
+                    source = InitialEventAwareLoadStates,
+                ),
+        )
+        private set
+
+    fun access(index: Int) {
+        if (index in 0 until pagingDataPresenter.size) {
+            pagingDataPresenter[index]
+        }
+    }
+
+    fun retry() {
+        pagingDataPresenter.retry()
+    }
+
+    fun refresh() {
+        pagingDataPresenter.refresh()
+    }
+
+    suspend fun refreshSuspend() {
+        refresh()
+        snapshotFlow { loadState }
+            .distinctUntilChanged()
+            .first { it.refresh is LoadState.Loading }
+        snapshotFlow { loadState }
+            .distinctUntilChanged()
+            .first { it.refresh is LoadState.NotLoading || it.refresh is LoadState.Error }
+    }
+
+    suspend fun collectPagingData() {
+        flow.collectLatest(pagingDataPresenter::collectFrom)
+    }
+
+    suspend fun collectLoadState() {
+        pagingDataPresenter.loadStateFlow
+            .filterNotNull()
+            .collect { loadState = it }
+    }
+
+    private fun updateItems(event: PagingDataEvent<T>) {
+        val items = pagingDataPresenter.snapshot()
+        val presentation =
+            when (event) {
+                is PagingDataEvent.Append -> {
+                    presentationTracker.appendOrRefresh(
+                        startIndex = event.startIndex,
+                        inserted = event.inserted.map(mapper::map),
+                        newItems = items,
+                        mapper = mapper,
+                        hasPlaceholders =
+                            event.oldPlaceholdersAfter != 0 ||
+                                event.newPlaceholdersAfter != 0 ||
+                                items.placeholdersBefore != 0,
+                    )
+                }
+
+                is PagingDataEvent.Prepend -> {
+                    presentationTracker.prependOrRefresh(
+                        inserted = event.inserted.map(mapper::map),
+                        newItems = items,
+                        mapper = mapper,
+                        hasPlaceholders =
+                            event.oldPlaceholdersBefore != 0 ||
+                                event.newPlaceholdersBefore != 0 ||
+                                items.placeholdersAfter != 0,
+                    )
+                }
+
+                is PagingDataEvent.DropAppend -> {
+                    presentationTracker.removeOrRefresh(
+                        startIndex = event.startIndex,
+                        removeCount = event.dropCount,
+                        newItems = items,
+                        mapper = mapper,
+                        hasPlaceholders =
+                            event.oldPlaceholdersAfter != 0 ||
+                                event.newPlaceholdersAfter != 0 ||
+                                items.placeholdersBefore != 0,
+                    )
+                }
+
+                is PagingDataEvent.DropPrepend -> {
+                    presentationTracker.removeOrRefresh(
+                        startIndex = 0,
+                        removeCount = event.dropCount,
+                        newItems = items,
+                        mapper = mapper,
+                        hasPlaceholders =
+                            event.oldPlaceholdersBefore != 0 ||
+                                event.newPlaceholdersBefore != 0 ||
+                                items.placeholdersAfter != 0,
+                    )
+                }
+
+                is PagingDataEvent.Refresh -> {
+                    presentationTracker.refresh(items.toPresentationItems(mapper))
+                }
+            }
+        itemState = EventAwarePagingItemState(items = items, presentation = presentation)
+    }
+}
+
+internal data class EventAwarePagingItemState<T : Any>(
+    val items: ItemSnapshotList<T>,
+    val presentation: PagingPresentationSnapshot,
+)
+
+@Composable
+internal fun <T : Any> Flow<PagingData<T>>.collectAsEventAwarePagingItems(mapper: PagingPresentationMapper<T>): EventAwarePagingItems<T> {
+    val pagingItems = remember(this) { EventAwarePagingItems(flow = this, mapper = mapper) }
+    LaunchedEffect(pagingItems) {
+        pagingItems.collectPagingData()
+    }
+    LaunchedEffect(pagingItems) {
+        pagingItems.collectLoadState()
+    }
+    return pagingItems
+}
+
+private fun <T : Any> ItemSnapshotList<T>.toPresentationItems(
+    mapper: PagingPresentationMapper<T>,
+): PersistentList<PagingPresentationItem> {
+    val result = persistentListOf<PagingPresentationItem>().builder()
+    with(result) {
+        repeat(placeholdersBefore) {
+            add(PlaceholderPresentationItem)
+        }
+        items.forEach { add(mapper.map(it)) }
+        repeat(placeholdersAfter) {
+            add(PlaceholderPresentationItem)
+        }
+    }
+    return result.build()
+}
+
+internal class PagingPresentationTracker(
+    initialItems: PersistentList<PagingPresentationItem> = persistentListOf(),
+) {
+    private var items = initialItems
+    private var revision = 0L
+
+    var snapshot: PagingPresentationSnapshot =
+        PagingPresentationSnapshot(
+            revision = revision,
+            presentedItems = items,
+            change = null,
+        )
+        private set
+
+    fun <T : Any> appendOrRefresh(
+        startIndex: Int,
+        inserted: List<PagingPresentationItem>,
+        newItems: ItemSnapshotList<T>,
+        mapper: PagingPresentationMapper<T>,
+        hasPlaceholders: Boolean,
+    ): PagingPresentationSnapshot =
+        if (
+            !hasPlaceholders &&
+            startIndex == items.size &&
+            newItems.size == items.size + inserted.size
+        ) {
+            replace(startIndex = startIndex, removeCount = 0, inserted = inserted)
+        } else {
+            refresh(newItems.toPresentationItems(mapper))
+        }
+
+    fun <T : Any> prependOrRefresh(
+        inserted: List<PagingPresentationItem>,
+        newItems: ItemSnapshotList<T>,
+        mapper: PagingPresentationMapper<T>,
+        hasPlaceholders: Boolean,
+    ): PagingPresentationSnapshot =
+        if (!hasPlaceholders && newItems.size == items.size + inserted.size) {
+            replace(startIndex = 0, removeCount = 0, inserted = inserted)
+        } else {
+            refresh(newItems.toPresentationItems(mapper))
+        }
+
+    fun <T : Any> removeOrRefresh(
+        startIndex: Int,
+        removeCount: Int,
+        newItems: ItemSnapshotList<T>,
+        mapper: PagingPresentationMapper<T>,
+        hasPlaceholders: Boolean,
+    ): PagingPresentationSnapshot =
+        if (
+            !hasPlaceholders &&
+            startIndex >= 0 &&
+            removeCount >= 0 &&
+            startIndex + removeCount <= items.size &&
+            newItems.size == items.size - removeCount
+        ) {
+            replace(startIndex = startIndex, removeCount = removeCount, inserted = emptyList())
+        } else {
+            refresh(newItems.toPresentationItems(mapper))
+        }
+
+    fun refresh(nextItems: PersistentList<PagingPresentationItem>): PagingPresentationSnapshot {
+        val previousItems = items
+        var prefixSize = 0
+        val sharedSize = minOf(previousItems.size, nextItems.size)
+        while (
+            prefixSize < sharedSize &&
+            previousItems[prefixSize].sameIdentityAs(nextItems[prefixSize])
+        ) {
+            prefixSize++
+        }
+
+        var suffixSize = 0
+        while (
+            suffixSize < sharedSize - prefixSize &&
+            previousItems[previousItems.lastIndex - suffixSize]
+                .sameIdentityAs(nextItems[nextItems.lastIndex - suffixSize])
+        ) {
+            suffixSize++
+        }
+
+        val previousChangedEnd = previousItems.size - suffixSize
+        val nextChangedEnd = nextItems.size - suffixSize
+        val replacement =
+            if (prefixSize != previousChangedEnd || prefixSize != nextChangedEnd) {
+                PagingPresentationReplacement(
+                    startIndex = prefixSize,
+                    removeCount = previousChangedEnd - prefixSize,
+                    insertedItems = nextItems.subList(prefixSize, nextChangedEnd),
+                )
+            } else {
+                null
+            }
+
+        val reloaded =
+            buildList {
+                for (index in 0 until prefixSize) {
+                    addIfChanged(previousItems[index], nextItems[index])
+                }
+                for (offset in 0 until suffixSize) {
+                    val previous = previousItems[previousItems.lastIndex - offset]
+                    val next = nextItems[nextItems.lastIndex - offset]
+                    addIfChanged(previous, next)
+                }
+            }
+        return commit(nextItems, replacement, reloaded)
+    }
+
+    private fun replace(
+        startIndex: Int,
+        removeCount: Int,
+        inserted: List<PagingPresentationItem>,
+    ): PagingPresentationSnapshot {
+        if (removeCount == 0 && inserted.isEmpty()) {
+            return snapshot
+        }
+        val nextItems =
+            items.builder().run {
+                repeat(removeCount) {
+                    removeAt(startIndex)
+                }
+                addAll(startIndex, inserted)
+                build()
+            }
+        return commit(
+            nextItems = nextItems,
+            replacement =
+                PagingPresentationReplacement(
+                    startIndex = startIndex,
+                    removeCount = removeCount,
+                    insertedItems = inserted,
+                ),
+            reloadedItems = emptyList(),
+        )
+    }
+
+    private fun commit(
+        nextItems: PersistentList<PagingPresentationItem>,
+        replacement: PagingPresentationReplacement?,
+        reloadedItems: List<PagingPresentationItem>,
+    ): PagingPresentationSnapshot {
+        if (replacement == null && reloadedItems.isEmpty()) {
+            return snapshot
+        }
+        val baseRevision = revision
+        revision++
+        items = nextItems
+        snapshot =
+            PagingPresentationSnapshot(
+                revision = revision,
+                presentedItems = items,
+                change =
+                    PagingPresentationChange(
+                        baseRevision = baseRevision,
+                        revision = revision,
+                        replacement = replacement,
+                        reloadedItems = reloadedItems,
+                    ),
+            )
+        return snapshot
+    }
+
+    private fun MutableList<PagingPresentationItem>.addIfChanged(
+        previous: PagingPresentationItem,
+        next: PagingPresentationItem,
+    ) {
+        if (previous.renderHash != next.renderHash) {
+            add(next)
+        }
+    }
+}
+
+private fun PagingPresentationItem.sameIdentityAs(other: PagingPresentationItem): Boolean = key == other.key
+
+private val PlaceholderPresentationItem = PagingPresentationItem(key = null, renderHash = 0)
+
+private val IncompleteEventAwareLoadState = LoadState.NotLoading(endOfPaginationReached = false)
+private val InitialEventAwareLoadStates =
+    LoadStates(
+        refresh = LoadState.Loading,
+        prepend = IncompleteEventAwareLoadState,
+        append = IncompleteEventAwareLoadState,
+    )

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/common/PagingState.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/common/PagingState.kt
@@ -44,6 +44,9 @@ public sealed class PagingState<T> {
         public abstract val isRefreshing: Boolean
         public abstract val appendState: LoadState
 
+        /** Optional lightweight, versioned list metadata for event-aware platform renderers. */
+        public open val pagingPresentation: PagingPresentationSnapshot? = null
+
         public abstract operator fun get(index: Int): T?
 
         public abstract fun peek(index: Int): T?
@@ -119,6 +122,46 @@ public sealed class PagingState<T> {
             override fun itemKey(key: ((item: T) -> Any)?): (index: Int) -> Any = data.itemKey(key)
 
             override fun itemContentType(contentType: ((item: T) -> Any?)?): (index: Int) -> Any? = data.itemContentType(contentType)
+        }
+
+        @Immutable
+        internal data class EventAwarePagingSuccess<T : Any>(
+            private val data: EventAwarePagingItems<T>,
+            private val itemState: EventAwarePagingItemState<T>,
+            override val isRefreshing: Boolean,
+            override val appendState: LoadState,
+            override val pagingPresentation: PagingPresentationSnapshot,
+        ) : Success<T>() {
+            override val itemCount: Int = itemState.items.size
+
+            override fun get(index: Int): T? =
+                if (index !in 0 until itemCount) {
+                    null
+                } else {
+                    data.access(index)
+                    itemState.items[index]
+                }
+
+            override fun peek(index: Int): T? = itemState.items.getOrNull(index)
+
+            override suspend fun refreshSuspend() {
+                data.refreshSuspend()
+            }
+
+            override fun retry() {
+                data.retry()
+            }
+
+            override fun itemKey(key: ((item: T) -> Any)?): (index: Int) -> Any =
+                { index ->
+                    val item = itemState.items.getOrNull(index)
+                    item?.let { key?.invoke(it) }
+                        ?: pagingPresentation.itemAt(index)?.key
+                        ?: index
+                }
+
+            override fun itemContentType(contentType: ((item: T) -> Any?)?): (index: Int) -> Any? =
+                { index -> itemState.items.getOrNull(index)?.let { contentType?.invoke(it) } }
         }
     }
 }
@@ -294,6 +337,46 @@ internal fun <T : Any> LazyPagingItems<T>.snapshot(): PagingSnapshot =
         source = loadState.source,
         mediator = loadState.mediator,
     )
+
+internal fun <T : Any> EventAwarePagingItems<T>.toPagingState(): PagingState<T> {
+    val currentItems = itemState
+    val currentLoadState = loadState
+    val snapshot =
+        PagingSnapshot(
+            itemCount = currentItems.items.size,
+            refresh = currentLoadState.refresh,
+            prepend = currentLoadState.prepend,
+            append = currentLoadState.append,
+            source = currentLoadState.source,
+            mediator = currentLoadState.mediator,
+        )
+    return when {
+        currentItems.items.isNotEmpty() -> {
+            PagingState.Success.EventAwarePagingSuccess(
+                data = this,
+                itemState = currentItems,
+                isRefreshing = currentLoadState.refresh is LoadState.Loading,
+                appendState = currentLoadState.append,
+                pagingPresentation = currentItems.presentation,
+            )
+        }
+
+        snapshot.initialErrorOrNull() != null -> {
+            PagingState.Error(
+                error = checkNotNull(snapshot.initialErrorOrNull()),
+                onRetry = ::retry,
+            )
+        }
+
+        !snapshot.isResolvedEmpty() -> {
+            PagingState.Loading()
+        }
+
+        else -> {
+            PagingState.Empty(::refresh)
+        }
+    }
+}
 
 internal fun <T : Any> UiState<PagingState<T>>.flatten(): PagingState<T> =
     when (this) {

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/common/SerializableImmutableList.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/common/SerializableImmutableList.kt
@@ -22,7 +22,7 @@ public typealias SerializableImmutableList<T> =
 
 @HiddenFromObjC
 public class ImmutableListSerializer<T>(
-    private val dataSerializer: KSerializer<T>,
+    dataSerializer: KSerializer<T>,
 ) : KSerializer<ImmutableList<T>> {
     @OptIn(SealedSerializationApi::class)
     private class PersistentListDescriptor : SerialDescriptor by serialDescriptor<List<String>>() {
@@ -30,13 +30,14 @@ public class ImmutableListSerializer<T>(
     }
 
     override val descriptor: SerialDescriptor = PersistentListDescriptor()
+    private val delegate = ListSerializer(dataSerializer)
 
     override fun serialize(
         encoder: Encoder,
         value: ImmutableList<T>,
-    ): Unit = ListSerializer(dataSerializer).serialize(encoder, value.toList())
+    ): Unit = delegate.serialize(encoder, value)
 
-    override fun deserialize(decoder: Decoder): ImmutableList<T> = ListSerializer(dataSerializer).deserialize(decoder).toPersistentList()
+    override fun deserialize(decoder: Decoder): ImmutableList<T> = delegate.deserialize(decoder).toPersistentList()
 }
 
 internal typealias SerializableImmutableMap<K, V> =
@@ -44,8 +45,8 @@ internal typealias SerializableImmutableMap<K, V> =
     ImmutableMap<K, V>
 
 internal class ImmutableMapSerializer<K, V>(
-    private val keySerializer: KSerializer<K>,
-    private val valueSerializer: KSerializer<V>,
+    keySerializer: KSerializer<K>,
+    valueSerializer: KSerializer<V>,
 ) : KSerializer<ImmutableMap<K, V>> {
     @OptIn(SealedSerializationApi::class)
     private class PersistentMapDescriptor : SerialDescriptor by serialDescriptor<Map<String, String>>() {
@@ -53,12 +54,12 @@ internal class ImmutableMapSerializer<K, V>(
     }
 
     override val descriptor: SerialDescriptor = PersistentMapDescriptor()
+    private val delegate = MapSerializer(keySerializer, valueSerializer)
 
     override fun serialize(
         encoder: Encoder,
         value: ImmutableMap<K, V>,
-    ) = MapSerializer(keySerializer, valueSerializer).serialize(encoder, value.toMap())
+    ) = delegate.serialize(encoder, value)
 
-    override fun deserialize(decoder: Decoder): ImmutableMap<K, V> =
-        MapSerializer(keySerializer, valueSerializer).deserialize(decoder).toPersistentMap()
+    override fun deserialize(decoder: Decoder): ImmutableMap<K, V> = delegate.deserialize(decoder).toPersistentMap()
 }

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/ProvideDatabase.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/ProvideDatabase.kt
@@ -3,6 +3,7 @@ package dev.dimension.flare.data.database
 import dev.dimension.flare.common.PlatformDispatchers
 import dev.dimension.flare.data.database.app.AppDatabase
 import dev.dimension.flare.data.database.cache.CacheDatabase
+import dev.dimension.flare.data.database.cache.TimelineDependencyRevisionCallback
 import org.koin.core.annotation.Single
 
 @Single
@@ -24,6 +25,7 @@ internal const val CACHE_DATABASE_NAME = "cache.db"
 internal fun provideCacheDatabase(driverFactory: DriverFactory): CacheDatabase =
     driverFactory
         .createBuilder<CacheDatabase>(CACHE_DATABASE_NAME, isCache = true)
+        .addCallback(TimelineDependencyRevisionCallback)
         .fallbackToDestructiveMigration(dropAllTables = true)
         .setDriver(createDatabaseDriver())
         .setQueryCoroutineContext(PlatformDispatchers.IO)

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/CacaheDatabase.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/CacaheDatabase.kt
@@ -8,7 +8,7 @@ import androidx.room3.RoomDatabaseConstructor
 import androidx.room3.immediateTransaction
 import androidx.room3.useWriterConnection
 
-internal const val CACHE_DATABASE_VERSION = 46
+internal const val CACHE_DATABASE_VERSION = 49
 
 @Database(
     entities = [
@@ -38,6 +38,7 @@ internal const val CACHE_DATABASE_VERSION = 46
     dev.dimension.flare.data.database.adapter.MicroBlogKeyConverter::class,
     dev.dimension.flare.data.database.adapter.AccountTypeConverter::class,
     dev.dimension.flare.data.database.cache.model.EmojiContentConverter::class,
+    dev.dimension.flare.data.database.cache.model.DbTimelineContentConverter::class,
     dev.dimension.flare.data.database.cache.model.StatusConverter::class,
     dev.dimension.flare.data.database.cache.model.ListContentConverters::class,
     dev.dimension.flare.data.database.cache.model.TranslationConverters::class,
@@ -53,6 +54,8 @@ internal abstract class CacheDatabase : RoomDatabase() {
     abstract fun userDao(): dev.dimension.flare.data.database.cache.dao.UserDao
 
     abstract fun pagingTimelineDao(): dev.dimension.flare.data.database.cache.dao.PagingTimelineDao
+
+    abstract fun timelinePageDao(): dev.dimension.flare.data.database.cache.dao.TimelinePageDao
 
     abstract fun messageDao(): dev.dimension.flare.data.database.cache.dao.MessageDao
 

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/TimelineDependencyRevisionCallback.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/TimelineDependencyRevisionCallback.kt
@@ -1,0 +1,112 @@
+package dev.dimension.flare.data.database.cache
+
+import androidx.room3.RoomDatabase
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.async.executeSQL
+
+/** Installs mutation triggers that keep timeline dependency revisions current. */
+internal object TimelineDependencyRevisionCallback : RoomDatabase.Callback() {
+    override suspend fun onOpen(connection: SQLiteConnection) {
+        TIMELINE_DEPENDENCY_TRIGGER_SQL.forEach { connection.executeSQL(it) }
+    }
+}
+
+private val TIMELINE_DEPENDENCY_TRIGGER_SQL =
+    listOf(
+        statusTrigger(
+            name = "timeline_dependency_status_update",
+            event = "AFTER UPDATE OF contentHash, renderHash, text",
+            row = "NEW",
+            condition =
+                "WHEN OLD.contentHash IS NOT NEW.contentHash " +
+                    "OR OLD.renderHash IS NOT NEW.renderHash " +
+                    "OR OLD.text IS NOT NEW.text",
+        ),
+        statusTrigger(
+            name = "timeline_dependency_status_delete",
+            event = "AFTER DELETE",
+            row = "OLD",
+        ),
+        translationTrigger(
+            name = "timeline_dependency_translation_insert",
+            event = "AFTER INSERT",
+            row = "NEW",
+        ),
+        translationTrigger(
+            name = "timeline_dependency_translation_update_old",
+            event = "AFTER UPDATE OF entityType, entityKey, revision",
+            row = "OLD",
+            condition =
+                "WHEN OLD.entityType = 'Status' AND (" +
+                    "OLD.entityType IS NOT NEW.entityType OR " +
+                    "OLD.entityKey IS NOT NEW.entityKey OR " +
+                    "OLD.revision IS NOT NEW.revision)",
+        ),
+        translationTrigger(
+            name = "timeline_dependency_translation_update_new",
+            event = "AFTER UPDATE OF entityType, entityKey, revision",
+            row = "NEW",
+            condition =
+                "WHEN NEW.entityType = 'Status' AND (" +
+                    "OLD.entityType IS NOT NEW.entityType OR " +
+                    "OLD.entityKey IS NOT NEW.entityKey OR " +
+                    "OLD.revision IS NOT NEW.revision)",
+        ),
+        translationTrigger(
+            name = "timeline_dependency_translation_delete",
+            event = "AFTER DELETE",
+            row = "OLD",
+        ),
+    )
+
+private fun statusTrigger(
+    name: String,
+    event: String,
+    row: String,
+    condition: String = "",
+): String =
+    """
+    CREATE TRIGGER IF NOT EXISTS $name
+    $event ON DbStatus
+    $condition
+    BEGIN
+        ${dependencyRevisionUpdate("$row.id")}
+    END
+    """.trimIndent()
+
+private fun translationTrigger(
+    name: String,
+    event: String,
+    row: String,
+    condition: String = "WHEN $row.entityType = 'Status'",
+): String =
+    """
+    CREATE TRIGGER IF NOT EXISTS $name
+    $event ON DbTranslation
+    $condition
+    BEGIN
+        ${dependencyRevisionUpdate("$row.entityKey")}
+    END
+    """.trimIndent()
+
+private fun dependencyRevisionUpdate(statusId: String): String =
+    """
+    UPDATE DbPagingTimeline
+    SET dependencyRevision = dependencyRevision + 1
+    WHERE _id IN (
+        SELECT timeline._id
+        FROM DbPagingTimeline AS timeline
+        WHERE timeline.statusId = $statusId
+        UNION
+        SELECT timeline._id
+        FROM status_reference AS reference
+        INNER JOIN DbPagingTimeline AS timeline ON timeline.statusId = reference.statusId
+        WHERE reference.referenceStatusId = $statusId
+        UNION
+        SELECT timeline._id
+        FROM timeline_item_presentation_reference AS reference
+        INNER JOIN DbPagingTimeline AS timeline
+            ON timeline.pagingKey = reference.pagingKey AND timeline.statusId = reference.statusId
+        WHERE reference.referenceStatusId = $statusId
+    );
+    """.trimIndent()

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/TimelinePageIdentityReader.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/TimelinePageIdentityReader.kt
@@ -1,0 +1,35 @@
+package dev.dimension.flare.data.database.cache
+
+import dev.dimension.flare.data.database.cache.dao.DbTimelinePageIdentity
+import dev.dimension.flare.data.database.cache.dao.DbTimelinePageIdentityRoot
+
+/**
+ * Loads one fixed-width identity row per timeline item. Dependency revisions are maintained on the
+ * timeline row by batched cache writes and database triggers, so this path never materializes
+ * referenced status rows.
+ */
+internal suspend fun CacheDatabase.loadTimelinePageIdentities(
+    pagingKey: String,
+    offset: Int,
+    limit: Int,
+): List<DbTimelinePageIdentity> =
+    pagingTimelineDao()
+        .getTimelinePageIdentityRoots(
+            pagingKey = pagingKey,
+            offset = offset,
+            limit = limit,
+        ).toIdentities()
+
+private fun List<DbTimelinePageIdentityRoot>.toIdentities(): List<DbTimelinePageIdentity> =
+    map { root ->
+        DbTimelinePageIdentity(
+            statusId = root.statusId,
+            sortId = root.sortId,
+            rootContentHash = root.rootContentHash,
+            messageRenderHash = root.messageRenderHash,
+            statusReferenceHash = root.statusReferenceHash,
+            presentationReferenceHash = root.presentationReferenceHash,
+            dependencyCount = 0,
+            dependencyRevision = root.dependencyRevision,
+        )
+    }

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/TimelinePageReader.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/TimelinePageReader.kt
@@ -1,0 +1,153 @@
+package dev.dimension.flare.data.database.cache
+
+import androidx.room3.withReadTransaction
+import dev.dimension.flare.data.database.cache.dao.DbStatusFingerprint
+import dev.dimension.flare.data.database.cache.dao.TimelinePageDao
+import dev.dimension.flare.data.database.cache.model.DbPagingTimeline
+import dev.dimension.flare.data.database.cache.model.DbPagingTimelineWithStatus
+import dev.dimension.flare.data.database.cache.model.DbStatus
+import dev.dimension.flare.data.database.cache.model.DbStatusReferenceWithStatus
+import dev.dimension.flare.data.database.cache.model.DbStatusWithReference
+import dev.dimension.flare.data.database.cache.model.DbStatusWithUser
+import dev.dimension.flare.data.database.cache.model.DbTimelineItemPresentationReferenceWithStatus
+import dev.dimension.flare.data.database.cache.model.TranslationEntityType
+
+private const val SQL_IN_BATCH_SIZE = 500
+
+internal suspend fun CacheDatabase.loadTimelinePage(
+    pagingKey: String,
+    offset: Int,
+    limit: Int,
+): List<DbPagingTimelineWithStatus> =
+    withReadTransaction {
+        val dao = timelinePageDao()
+        dao
+            .getTimelineRows(
+                pagingKey = pagingKey,
+                offset = offset,
+                limit = limit,
+            ).hydrate(dao = dao, pagingKey = pagingKey)
+    }
+
+internal suspend fun CacheDatabase.loadTimelineItems(
+    pagingKey: String,
+    statusIds: List<String>,
+    reusableStatuses: Map<String, DbStatus> = emptyMap(),
+): List<DbPagingTimelineWithStatus> {
+    if (statusIds.isEmpty()) {
+        return emptyList()
+    }
+    val distinctStatusIds = statusIds.distinct()
+    return withReadTransaction {
+        val dao = timelinePageDao()
+        val rows =
+            distinctStatusIds
+                .chunked(SQL_IN_BATCH_SIZE)
+                .flatMap { dao.getTimelineRowsByStatusIds(pagingKey = pagingKey, statusIds = it) }
+        val hydratedById =
+            rows
+                .hydrate(
+                    dao = dao,
+                    pagingKey = pagingKey,
+                    reusableStatuses = reusableStatuses,
+                ).associateBy { it.timeline.statusId }
+        distinctStatusIds.mapNotNull(hydratedById::get)
+    }
+}
+
+private suspend fun List<DbPagingTimeline>.hydrate(
+    dao: TimelinePageDao,
+    pagingKey: String,
+    reusableStatuses: Map<String, DbStatus> = emptyMap(),
+): List<DbPagingTimelineWithStatus> {
+    if (isEmpty()) {
+        return emptyList()
+    }
+    val rootStatusIds = map { it.statusId }.distinct()
+    val statusReferences =
+        rootStatusIds
+            .chunked(SQL_IN_BATCH_SIZE)
+            .flatMap { dao.getStatusReferences(it) }
+    val presentationReferences =
+        rootStatusIds
+            .chunked(SQL_IN_BATCH_SIZE)
+            .flatMap { dao.getPresentationReferences(pagingKey = pagingKey, statusIds = it) }
+    val allStatusIds =
+        buildSet {
+            addAll(rootStatusIds)
+            statusReferences.forEach { add(it.referenceStatusId) }
+            presentationReferences.forEach { add(it.referenceStatusId) }
+        }.toList()
+    val reusableIds = allStatusIds.filter { it in reusableStatuses }
+    val reusableFingerprints =
+        reusableIds
+            .chunked(SQL_IN_BATCH_SIZE)
+            .flatMap { dao.getStatusFingerprints(it) }
+            .associateBy { it.id }
+    val reusedStatuses =
+        reusableIds
+            .mapNotNull { statusId ->
+                val status = reusableStatuses[statusId] ?: return@mapNotNull null
+                val fingerprint = reusableFingerprints[statusId] ?: return@mapNotNull null
+                status.takeIf { it.hasSameStoredContentAs(fingerprint) }
+            }.associateBy { it.id }
+    val fetchedStatuses =
+        allStatusIds
+            .filterNot { it in reusedStatuses }
+            .chunked(SQL_IN_BATCH_SIZE)
+            .flatMap { dao.getStatuses(it) }
+            .associateBy { it.id }
+    val translations =
+        allStatusIds
+            .chunked(SQL_IN_BATCH_SIZE)
+            .flatMap {
+                dao.getTranslations(
+                    entityType = TranslationEntityType.Status,
+                    entityKeys = it,
+                )
+            }.groupBy { it.entityKey }
+    val statusesById =
+        allStatusIds
+            .mapNotNull { statusId ->
+                val status = reusedStatuses[statusId] ?: fetchedStatuses[statusId] ?: return@mapNotNull null
+                statusId to
+                    DbStatusWithUser(
+                        data = status,
+                        translations = translations[status.id].orEmpty(),
+                    )
+            }.toMap()
+    val referencesByStatusId =
+        statusReferences
+            .map { reference ->
+                DbStatusReferenceWithStatus(
+                    reference = reference,
+                    status = statusesById[reference.referenceStatusId],
+                )
+            }.groupBy { it.reference.statusId }
+    val presentationReferencesByStatusId =
+        presentationReferences
+            .map { reference ->
+                DbTimelineItemPresentationReferenceWithStatus(
+                    reference = reference,
+                    status = statusesById[reference.referenceStatusId],
+                )
+            }.groupBy { it.reference.statusId }
+
+    return mapNotNull { timeline ->
+        val status = statusesById[timeline.statusId] ?: return@mapNotNull null
+        DbPagingTimelineWithStatus(
+            timeline = timeline,
+            status =
+                DbStatusWithReference(
+                    status = status,
+                    references = referencesByStatusId[timeline.statusId].orEmpty(),
+                ),
+            presentationReferences = presentationReferencesByStatusId[timeline.statusId].orEmpty(),
+        )
+    }
+}
+
+private fun DbStatus.hasSameStoredContentAs(fingerprint: DbStatusFingerprint): Boolean =
+    id == fingerprint.id &&
+        contentHash == fingerprint.contentHash &&
+        renderHash == fingerprint.renderHash

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/dao/PagingTimelineDao.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/dao/PagingTimelineDao.kt
@@ -23,11 +23,22 @@ import kotlinx.coroutines.flow.Flow
 internal data class DbTimelinePageIdentity(
     val statusId: String,
     val sortId: Long,
-    val rootRenderHash: Int,
+    val rootContentHash: Long,
     val messageRenderHash: Int?,
-    val rootTranslationSignature: String,
-    val referenceCount: Long,
-    val referenceSignature: String,
+    val statusReferenceHash: Long,
+    val presentationReferenceHash: Long,
+    val dependencyCount: Int,
+    val dependencyRevision: Long,
+)
+
+internal data class DbTimelinePageIdentityRoot(
+    val statusId: String,
+    val sortId: Long,
+    val rootContentHash: Long,
+    val messageRenderHash: Int?,
+    val statusReferenceHash: Long,
+    val presentationReferenceHash: Long,
+    val dependencyRevision: Long,
 )
 
 @Dao
@@ -41,10 +52,14 @@ internal interface PagingTimelineDao {
             "DbPagingTimeline.sortId AS sortId, " +
             "DbPagingTimeline.message AS message, " +
             "DbPagingTimeline.messageRenderHash AS messageRenderHash, " +
+            "DbPagingTimeline.statusReferenceHash AS statusReferenceHash, " +
+            "DbPagingTimeline.presentationReferenceHash AS presentationReferenceHash, " +
+            "DbPagingTimeline.dependencyRevision AS dependencyRevision, " +
             "DbPagingTimeline._id AS _id, " +
             "DbStatus.statusKey AS status_statusKey, " +
             "DbStatus.accountType AS status_accountType, " +
             "DbStatus.content AS status_content, " +
+            "DbStatus.contentHash AS status_contentHash, " +
             "DbStatus.renderHash AS status_renderHash, " +
             "DbStatus.text AS status_text, " +
             "DbStatus.id AS status_id " +
@@ -66,10 +81,14 @@ internal interface PagingTimelineDao {
             "DbPagingTimeline.sortId AS sortId, " +
             "DbPagingTimeline.message AS message, " +
             "DbPagingTimeline.messageRenderHash AS messageRenderHash, " +
+            "DbPagingTimeline.statusReferenceHash AS statusReferenceHash, " +
+            "DbPagingTimeline.presentationReferenceHash AS presentationReferenceHash, " +
+            "DbPagingTimeline.dependencyRevision AS dependencyRevision, " +
             "DbPagingTimeline._id AS _id, " +
             "DbStatus.statusKey AS status_statusKey, " +
             "DbStatus.accountType AS status_accountType, " +
             "DbStatus.content AS status_content, " +
+            "DbStatus.contentHash AS status_contentHash, " +
             "DbStatus.renderHash AS status_renderHash, " +
             "DbStatus.text AS status_text, " +
             "DbStatus.id AS status_id " +
@@ -80,121 +99,43 @@ internal interface PagingTimelineDao {
     )
     fun getPagingSource(pagingKey: String): PagingSource<Int, DbPagingTimelineWithStatus>
 
-    @Transaction
     @Query(
         "SELECT " +
-            "DbPagingTimeline.pagingKey AS pagingKey, " +
             "DbPagingTimeline.statusId AS statusId, " +
             "DbPagingTimeline.sortId AS sortId, " +
-            "DbPagingTimeline.message AS message, " +
+            "DbStatus.contentHash AS rootContentHash, " +
             "DbPagingTimeline.messageRenderHash AS messageRenderHash, " +
-            "DbPagingTimeline._id AS _id, " +
-            "DbStatus.statusKey AS status_statusKey, " +
-            "DbStatus.accountType AS status_accountType, " +
-            "DbStatus.content AS status_content, " +
-            "DbStatus.renderHash AS status_renderHash, " +
-            "DbStatus.text AS status_text, " +
-            "DbStatus.id AS status_id " +
+            "DbPagingTimeline.statusReferenceHash AS statusReferenceHash, " +
+            "DbPagingTimeline.presentationReferenceHash AS presentationReferenceHash, " +
+            "DbPagingTimeline.dependencyRevision AS dependencyRevision " +
             "FROM DbPagingTimeline " +
             "INNER JOIN DbStatus ON DbStatus.id = DbPagingTimeline.statusId " +
             "WHERE DbPagingTimeline.pagingKey = :pagingKey " +
             "ORDER BY DbPagingTimeline.sortId " +
             "LIMIT :limit OFFSET :offset",
     )
-    suspend fun getTimelinePage(
+    suspend fun getTimelinePageIdentityRoots(
         pagingKey: String,
         offset: Int,
         limit: Int,
-    ): List<DbPagingTimelineWithStatus>
+    ): List<DbTimelinePageIdentityRoot>
 
     @Query(
-        "WITH page AS (" +
-            "SELECT " +
-            "DbStatus.id AS statusId, " +
-            "DbPagingTimeline.sortId AS sortId, " +
-            "DbPagingTimeline.messageRenderHash AS messageRenderHash, " +
-            "DbStatus.renderHash AS rootRenderHash " +
-            "FROM DbStatus " +
-            "INNER JOIN DbPagingTimeline ON DbStatus.id = DbPagingTimeline.statusId " +
-            "WHERE DbPagingTimeline.pagingKey = :pagingKey " +
-            "ORDER BY DbPagingTimeline.sortId " +
-            "LIMIT :limit OFFSET :offset" +
-            "), translation_rows AS (" +
-            "SELECT " +
-            "DbTranslation.entityKey AS statusId, " +
-            "DbTranslation.id || ':' || DbTranslation.status || ':' || DbTranslation.displayMode || ':' || " +
-            "DbTranslation.updatedAt || ':' || DbTranslation.sourceHash AS signature " +
-            "FROM DbTranslation " +
-            "WHERE DbTranslation.entityType = 'Status' " +
-            "AND DbTranslation.entityKey IN (" +
-            "SELECT statusId FROM page " +
-            "UNION " +
-            "SELECT status_reference.referenceStatusId FROM status_reference " +
-            "WHERE status_reference.statusId IN (SELECT statusId FROM page) " +
-            "UNION " +
-            "SELECT timeline_item_presentation_reference.referenceStatusId " +
-            "FROM timeline_item_presentation_reference " +
-            "WHERE timeline_item_presentation_reference.pagingKey = :pagingKey " +
-            "AND timeline_item_presentation_reference.statusId IN (SELECT statusId FROM page)" +
+        "WITH boundary AS (" +
+            "SELECT sortId FROM DbPagingTimeline " +
+            "WHERE pagingKey = :pagingKey AND statusId = :statusId " +
+            "LIMIT 1" +
             ") " +
-            "ORDER BY DbTranslation.id" +
-            "), translation_stats AS (" +
-            "SELECT " +
-            "statusId AS statusId, " +
-            "COALESCE(GROUP_CONCAT(signature, '|'), '') AS signature " +
-            "FROM translation_rows " +
-            "GROUP BY statusId" +
-            "), reference_rows AS (" +
-            "SELECT " +
-            "status_reference.statusId AS statusId, " +
-            "'semantic:' || status_reference.referenceOrder || ':' || status_reference.referenceType || ':' || " +
-            "status_reference.referenceStatusId || ':' || ReferenceStatus.renderHash || ':' || " +
-            "COALESCE(translation_stats.signature, '') AS signature " +
-            "FROM status_reference " +
-            "INNER JOIN DbStatus AS ReferenceStatus ON status_reference.referenceStatusId = ReferenceStatus.id " +
-            "LEFT JOIN translation_stats ON status_reference.referenceStatusId = translation_stats.statusId " +
-            "WHERE status_reference.statusId IN (SELECT statusId FROM page) " +
-            "UNION ALL " +
-            "SELECT " +
-            "timeline_item_presentation_reference.statusId AS statusId, " +
-            "'presentation:' || timeline_item_presentation_reference.referenceOrder || ':' || " +
-            "timeline_item_presentation_reference.presentationType || ':' || " +
-            "timeline_item_presentation_reference.referenceStatusId || ':' || PresentationStatus.renderHash || ':' || " +
-            "COALESCE(presentation_translation_stats.signature, '') AS signature " +
-            "FROM timeline_item_presentation_reference " +
-            "INNER JOIN DbStatus AS PresentationStatus " +
-            "ON timeline_item_presentation_reference.referenceStatusId = PresentationStatus.id " +
-            "LEFT JOIN translation_stats AS presentation_translation_stats " +
-            "ON timeline_item_presentation_reference.referenceStatusId = presentation_translation_stats.statusId " +
-            "WHERE timeline_item_presentation_reference.pagingKey = :pagingKey " +
-            "AND timeline_item_presentation_reference.statusId IN (SELECT statusId FROM page) " +
-            "ORDER BY statusId, signature" +
-            "), reference_stats AS (" +
-            "SELECT " +
-            "reference_rows.statusId AS statusId, " +
-            "COUNT(*) AS referenceCount, " +
-            "COALESCE(GROUP_CONCAT(reference_rows.signature, '|'), '') AS referenceSignature " +
-            "FROM reference_rows " +
-            "GROUP BY reference_rows.statusId" +
-            ") " +
-            "SELECT " +
-            "page.statusId AS statusId, " +
-            "page.sortId AS sortId, " +
-            "page.rootRenderHash AS rootRenderHash, " +
-            "page.messageRenderHash AS messageRenderHash, " +
-            "COALESCE(root_translation_stats.signature, '') AS rootTranslationSignature, " +
-            "COALESCE(reference_stats.referenceCount, 0) AS referenceCount, " +
-            "COALESCE(reference_stats.referenceSignature, '') AS referenceSignature " +
-            "FROM page " +
-            "LEFT JOIN reference_stats ON page.statusId = reference_stats.statusId " +
-            "LEFT JOIN translation_stats AS root_translation_stats ON page.statusId = root_translation_stats.statusId " +
-            "ORDER BY page.sortId",
+            "SELECT COUNT(*) FROM DbPagingTimeline AS candidate " +
+            "INNER JOIN DbStatus ON DbStatus.id = candidate.statusId " +
+            "CROSS JOIN boundary " +
+            "WHERE candidate.pagingKey = :pagingKey " +
+            "AND candidate.sortId <= boundary.sortId",
     )
-    suspend fun getTimelinePageIdentities(
+    suspend fun getTimelinePrefixLengthThroughStatus(
         pagingKey: String,
-        offset: Int,
-        limit: Int,
-    ): List<DbTimelinePageIdentity>
+        statusId: String,
+    ): Int
 
     @Transaction
     @RewriteQueriesToDropUnusedColumns
@@ -224,10 +165,14 @@ internal interface PagingTimelineDao {
             "DbPagingTimeline.sortId AS sortId, " +
             "DbPagingTimeline.message AS message, " +
             "DbPagingTimeline.messageRenderHash AS messageRenderHash, " +
+            "DbPagingTimeline.statusReferenceHash AS statusReferenceHash, " +
+            "DbPagingTimeline.presentationReferenceHash AS presentationReferenceHash, " +
+            "DbPagingTimeline.dependencyRevision AS dependencyRevision, " +
             "DbPagingTimeline._id AS _id, " +
             "DbStatus.statusKey AS status_statusKey, " +
             "DbStatus.accountType AS status_accountType, " +
             "DbStatus.content AS status_content, " +
+            "DbStatus.contentHash AS status_contentHash, " +
             "DbStatus.renderHash AS status_renderHash, " +
             "DbStatus.text AS status_text, " +
             "DbStatus.id AS status_id " +
@@ -250,10 +195,14 @@ internal interface PagingTimelineDao {
             "DbPagingTimeline.sortId AS sortId, " +
             "DbPagingTimeline.message AS message, " +
             "DbPagingTimeline.messageRenderHash AS messageRenderHash, " +
+            "DbPagingTimeline.statusReferenceHash AS statusReferenceHash, " +
+            "DbPagingTimeline.presentationReferenceHash AS presentationReferenceHash, " +
+            "DbPagingTimeline.dependencyRevision AS dependencyRevision, " +
             "DbPagingTimeline._id AS _id, " +
             "DbStatus.statusKey AS status_statusKey, " +
             "DbStatus.accountType AS status_accountType, " +
             "DbStatus.content AS status_content, " +
+            "DbStatus.contentHash AS status_contentHash, " +
             "DbStatus.renderHash AS status_renderHash, " +
             "DbStatus.text AS status_text, " +
             "DbStatus.id AS status_id " +
@@ -272,10 +221,14 @@ internal interface PagingTimelineDao {
             "DbPagingTimeline.sortId AS sortId, " +
             "DbPagingTimeline.message AS message, " +
             "DbPagingTimeline.messageRenderHash AS messageRenderHash, " +
+            "DbPagingTimeline.statusReferenceHash AS statusReferenceHash, " +
+            "DbPagingTimeline.presentationReferenceHash AS presentationReferenceHash, " +
+            "DbPagingTimeline.dependencyRevision AS dependencyRevision, " +
             "DbPagingTimeline._id AS _id, " +
             "DbStatus.statusKey AS status_statusKey, " +
             "DbStatus.accountType AS status_accountType, " +
             "DbStatus.content AS status_content, " +
+            "DbStatus.contentHash AS status_contentHash, " +
             "DbStatus.renderHash AS status_renderHash, " +
             "DbStatus.text AS status_text, " +
             "DbStatus.id AS status_id " +
@@ -309,6 +262,18 @@ internal interface PagingTimelineDao {
     suspend fun deletePresentationReferences(pagingKey: String)
 
     @Query(
+        "SELECT * FROM timeline_item_presentation_reference " +
+            "WHERE pagingKey = :pagingKey AND statusId IN (:statusIds)",
+    )
+    suspend fun getPresentationReferences(
+        pagingKey: String,
+        statusIds: List<String>,
+    ): List<DbTimelineItemPresentationReference>
+
+    @Delete
+    suspend fun deletePresentationReferenceItems(items: List<DbTimelineItemPresentationReference>)
+
+    @Query(
         "SELECT * FROM DbPagingTimeline " +
             "WHERE pagingKey = :pagingKey AND statusId IN (:statusIds)",
     )
@@ -331,10 +296,14 @@ internal interface PagingTimelineDao {
             "DbPagingTimeline.sortId AS sortId, " +
             "DbPagingTimeline.message AS message, " +
             "DbPagingTimeline.messageRenderHash AS messageRenderHash, " +
+            "DbPagingTimeline.statusReferenceHash AS statusReferenceHash, " +
+            "DbPagingTimeline.presentationReferenceHash AS presentationReferenceHash, " +
+            "DbPagingTimeline.dependencyRevision AS dependencyRevision, " +
             "DbPagingTimeline._id AS _id, " +
             "DbStatus.statusKey AS status_statusKey, " +
             "DbStatus.accountType AS status_accountType, " +
             "DbStatus.content AS status_content, " +
+            "DbStatus.contentHash AS status_contentHash, " +
             "DbStatus.renderHash AS status_renderHash, " +
             "DbStatus.text AS status_text, " +
             "DbStatus.id AS status_id " +

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/dao/StatusDao.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/dao/StatusDao.kt
@@ -7,10 +7,21 @@ import androidx.room3.Query
 import androidx.room3.Transaction
 import dev.dimension.flare.data.database.cache.model.DbStatus
 import dev.dimension.flare.data.database.cache.model.DbStatusWithReference
+import dev.dimension.flare.data.database.cache.model.DbTimelineContent
 import dev.dimension.flare.model.DbAccountType
 import dev.dimension.flare.model.MicroBlogKey
 import dev.dimension.flare.ui.model.UiTimelineV2
 import kotlinx.coroutines.flow.Flow
+
+internal data class DbStatusFingerprint(
+    val id: String,
+    val contentHash: Long,
+    val renderHash: Int,
+)
+
+internal data class DbStatusId(
+    val id: String,
+)
 
 @Dao
 internal interface StatusDao {
@@ -40,23 +51,76 @@ internal interface StatusDao {
         accountType: DbAccountType,
     ): DbStatusWithReference?
 
-    @Query("SELECT * FROM DbStatus WHERE accountType = :accountType AND statusKey IN (:statusKeys)")
-    suspend fun getByKeys(
-        statusKeys: List<MicroBlogKey>,
-        accountType: DbAccountType,
-    ): List<DbStatus>
+    @Query("SELECT id, contentHash, renderHash FROM DbStatus WHERE id IN (:statusIds)")
+    suspend fun getFingerprints(statusIds: List<String>): List<DbStatusFingerprint>
 
     @Query(
-        "UPDATE DbStatus SET content = :content, renderHash = :renderHash, text = :text " +
+        "SELECT timeline.statusId AS id FROM DbPagingTimeline AS timeline " +
+            "LEFT JOIN DbStatus AS status ON status.id = timeline.statusId " +
+            "WHERE status.id IS NULL " +
+            "UNION " +
+            "SELECT reference.referenceStatusId AS id FROM status_reference AS reference " +
+            "INNER JOIN DbPagingTimeline AS timeline ON timeline.statusId = reference.statusId " +
+            "LEFT JOIN DbStatus AS status ON status.id = reference.referenceStatusId " +
+            "WHERE status.id IS NULL " +
+            "UNION " +
+            "SELECT reference.referenceStatusId AS id " +
+            "FROM timeline_item_presentation_reference AS reference " +
+            "INNER JOIN DbPagingTimeline AS timeline " +
+            "ON timeline.pagingKey = reference.pagingKey AND timeline.statusId = reference.statusId " +
+            "LEFT JOIN DbStatus AS status ON status.id = reference.referenceStatusId " +
+            "WHERE status.id IS NULL",
+    )
+    suspend fun getMissingTimelineDependencyStatusIds(): List<DbStatusId>
+
+    @Query(
+        "UPDATE DbPagingTimeline SET dependencyRevision = dependencyRevision + 1 " +
+            "WHERE _id IN (" +
+            "SELECT timeline._id FROM DbPagingTimeline AS timeline " +
+            "WHERE timeline.statusId IN (:statusIds) " +
+            "UNION " +
+            "SELECT timeline._id FROM status_reference AS reference " +
+            "INNER JOIN DbPagingTimeline AS timeline ON timeline.statusId = reference.statusId " +
+            "WHERE reference.referenceStatusId IN (:statusIds) " +
+            "UNION " +
+            "SELECT timeline._id FROM timeline_item_presentation_reference AS reference " +
+            "INNER JOIN DbPagingTimeline AS timeline " +
+            "ON timeline.pagingKey = reference.pagingKey AND timeline.statusId = reference.statusId " +
+            "WHERE reference.referenceStatusId IN (:statusIds)" +
+            ")",
+    )
+    suspend fun bumpTimelineDependencies(statusIds: List<String>)
+
+    @Query(
+        "UPDATE DbStatus SET content = :content, contentHash = :contentHash, renderHash = :renderHash, text = :text " +
             "WHERE statusKey = :statusKey AND accountType = :accountType",
     )
+    suspend fun updateStoredContent(
+        statusKey: MicroBlogKey,
+        accountType: DbAccountType,
+        content: DbTimelineContent,
+        contentHash: Long,
+        renderHash: Int,
+        text: String?,
+    )
+
     suspend fun update(
         statusKey: MicroBlogKey,
         accountType: DbAccountType,
         content: UiTimelineV2,
         renderHash: Int,
         text: String?,
-    )
+    ) {
+        val storedContent = DbTimelineContent.encode(content)
+        updateStoredContent(
+            statusKey = statusKey,
+            accountType = accountType,
+            content = storedContent,
+            contentHash = storedContent.contentHash,
+            renderHash = renderHash,
+            text = text,
+        )
+    }
 
     @Query("DELETE FROM DbStatus WHERE statusKey = :statusKey AND accountType = :accountType")
     suspend fun delete(

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/dao/StatusReferenceDao.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/dao/StatusReferenceDao.kt
@@ -1,6 +1,7 @@
 package dev.dimension.flare.data.database.cache.dao
 
 import androidx.room3.Dao
+import androidx.room3.Delete
 import androidx.room3.Insert
 import androidx.room3.OnConflictStrategy
 import androidx.room3.Query
@@ -26,4 +27,10 @@ internal interface StatusReferenceDao {
 
     @Query("SELECT * FROM status_reference WHERE statusId = :statusId")
     suspend fun getByStatusId(statusId: String): List<DbStatusReference>
+
+    @Query("SELECT * FROM status_reference WHERE statusId in (:statusIds)")
+    suspend fun getByStatusIds(statusIds: List<String>): List<DbStatusReference>
+
+    @Delete
+    suspend fun deleteItems(items: List<DbStatusReference>)
 }

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/dao/TimelinePageDao.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/dao/TimelinePageDao.kt
@@ -1,0 +1,89 @@
+package dev.dimension.flare.data.database.cache.dao
+
+import androidx.room3.Dao
+import androidx.room3.Query
+import dev.dimension.flare.data.database.cache.model.DbPagingTimeline
+import dev.dimension.flare.data.database.cache.model.DbStatus
+import dev.dimension.flare.data.database.cache.model.DbStatusReference
+import dev.dimension.flare.data.database.cache.model.DbTimelineItemPresentationReference
+import dev.dimension.flare.data.database.cache.model.DbTranslation
+import dev.dimension.flare.data.database.cache.model.TranslationEntityType
+
+@Dao
+internal interface TimelinePageDao {
+    @Query(
+        "SELECT " +
+            "DbPagingTimeline.pagingKey, " +
+            "DbPagingTimeline.statusId, " +
+            "DbPagingTimeline.sortId, " +
+            "DbPagingTimeline.message, " +
+            "DbPagingTimeline.messageRenderHash, " +
+            "DbPagingTimeline.statusReferenceHash, " +
+            "DbPagingTimeline.presentationReferenceHash, " +
+            "DbPagingTimeline.dependencyRevision, " +
+            "DbPagingTimeline._id " +
+            "FROM DbPagingTimeline " +
+            "INNER JOIN DbStatus ON DbStatus.id = DbPagingTimeline.statusId " +
+            "WHERE DbPagingTimeline.pagingKey = :pagingKey " +
+            "ORDER BY DbPagingTimeline.sortId " +
+            "LIMIT :limit OFFSET :offset",
+    )
+    suspend fun getTimelineRows(
+        pagingKey: String,
+        offset: Int,
+        limit: Int,
+    ): List<DbPagingTimeline>
+
+    @Query(
+        "SELECT " +
+            "DbPagingTimeline.pagingKey, " +
+            "DbPagingTimeline.statusId, " +
+            "DbPagingTimeline.sortId, " +
+            "DbPagingTimeline.message, " +
+            "DbPagingTimeline.messageRenderHash, " +
+            "DbPagingTimeline.statusReferenceHash, " +
+            "DbPagingTimeline.presentationReferenceHash, " +
+            "DbPagingTimeline.dependencyRevision, " +
+            "DbPagingTimeline._id " +
+            "FROM DbPagingTimeline " +
+            "INNER JOIN DbStatus ON DbStatus.id = DbPagingTimeline.statusId " +
+            "WHERE DbPagingTimeline.pagingKey = :pagingKey " +
+            "AND DbPagingTimeline.statusId IN (:statusIds)",
+    )
+    suspend fun getTimelineRowsByStatusIds(
+        pagingKey: String,
+        statusIds: List<String>,
+    ): List<DbPagingTimeline>
+
+    @Query(
+        "SELECT * FROM status_reference " +
+            "WHERE statusId IN (:statusIds) " +
+            "ORDER BY statusId, referenceOrder",
+    )
+    suspend fun getStatusReferences(statusIds: List<String>): List<DbStatusReference>
+
+    @Query(
+        "SELECT * FROM timeline_item_presentation_reference " +
+            "WHERE pagingKey = :pagingKey AND statusId IN (:statusIds) " +
+            "ORDER BY statusId, referenceOrder",
+    )
+    suspend fun getPresentationReferences(
+        pagingKey: String,
+        statusIds: List<String>,
+    ): List<DbTimelineItemPresentationReference>
+
+    @Query("SELECT * FROM DbStatus WHERE id IN (:statusIds)")
+    suspend fun getStatuses(statusIds: List<String>): List<DbStatus>
+
+    @Query("SELECT id, contentHash, renderHash FROM DbStatus WHERE id IN (:statusIds)")
+    suspend fun getStatusFingerprints(statusIds: List<String>): List<DbStatusFingerprint>
+
+    @Query(
+        "SELECT * FROM DbTranslation " +
+            "WHERE entityType = :entityType AND entityKey IN (:entityKeys)",
+    )
+    suspend fun getTranslations(
+        entityType: TranslationEntityType,
+        entityKeys: List<String>,
+    ): List<DbTranslation>
+}

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/dao/TranslationDao.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/dao/TranslationDao.kt
@@ -59,6 +59,7 @@ internal interface TranslationDao {
             "payload = :payload, " +
             "statusReason = :statusReason, " +
             "attemptCount = :attemptCount, " +
+            "revision = revision + 1, " +
             "updatedAt = :updatedAt " +
             "WHERE entityType = :entityType AND entityKey = :entityKey AND targetLanguage = :targetLanguage",
     )
@@ -78,6 +79,7 @@ internal interface TranslationDao {
     @Query(
         "UPDATE DbTranslation SET " +
             "displayMode = :displayMode, " +
+            "revision = revision + 1, " +
             "updatedAt = :updatedAt " +
             "WHERE entityType = :entityType AND entityKey = :entityKey AND targetLanguage = :targetLanguage",
     )
@@ -94,6 +96,7 @@ internal interface TranslationDao {
             "status = :failedStatus, " +
             "payload = NULL, " +
             "statusReason = :statusReason, " +
+            "revision = revision + 1, " +
             "updatedAt = :updatedAt " +
             "WHERE (status = :pendingStatus OR status = :translatingStatus) AND updatedAt < :staleBefore",
     )

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/dao/UserDao.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/dao/UserDao.kt
@@ -35,6 +35,9 @@ internal interface UserDao {
     @Query("SELECT * FROM DbUser WHERE userKey IN (:userKeys)")
     fun findByKeys(userKeys: List<MicroBlogKey>): Flow<List<DbUser>>
 
+    @Query("SELECT * FROM DbUser WHERE userKey IN (:userKeys)")
+    suspend fun findByKeysOnce(userKeys: List<MicroBlogKey>): List<DbUser>
+
     @Query("SELECT * FROM DbUser WHERE userKey = :userKey")
     fun findByKey(userKey: MicroBlogKey): Flow<DbUser?>
 

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/mapper/Microblog.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/mapper/Microblog.kt
@@ -4,6 +4,9 @@ import dev.dimension.flare.data.database.cache.CacheDatabase
 import dev.dimension.flare.data.database.cache.model.DbPagingTimeline
 import dev.dimension.flare.data.database.cache.model.DbPagingTimelineWithStatus
 import dev.dimension.flare.data.database.cache.model.DbStatus
+import dev.dimension.flare.data.database.cache.model.DbStatusReference
+import dev.dimension.flare.data.database.cache.model.DbTimelineItemPresentationReference
+import dev.dimension.flare.model.MicroBlogKey
 import dev.dimension.flare.ui.model.UiProfile
 import dev.dimension.flare.ui.model.UiTimelineV2
 
@@ -11,119 +14,266 @@ internal suspend fun saveToDatabase(
     database: CacheDatabase,
     items: List<DbPagingTimelineWithStatus>,
 ) {
-    val rootStatusIds = items.map { it.status.status.data.id }.distinct()
-    val statuses =
-        items.map { it.status.status.data } +
-            items
-                .flatMap { it.status.references }
-                .mapNotNull { it.status?.data } +
-            items
-                .flatMap { it.presentationReferences }
-                .mapNotNull { it.status?.data }
-    val users = statuses.flatMap { it.content.usersInContent() }.distinctBy { it.key }
-    database.upsertUsers(users.map { it.toDbUser() })
-    val changedStatuses = loadChangedStatuses(database, statuses)
-    if (changedStatuses.isNotEmpty()) {
-        database.statusDao().insertAll(changedStatuses)
+    val timelines = ArrayList<DbPagingTimeline>(items.size)
+    val statusesById = LinkedHashMap<String, DbStatus>(items.size * 2)
+    items.forEach { item ->
+        timelines += item.timeline
+        statusesById.getOrPut(item.statusData.id) { item.statusData }
     }
-    if (rootStatusIds.isNotEmpty()) {
-        database.statusReferenceDao().delete(rootStatusIds)
-    }
-    items.flatMap { it.status.references }.map { it.reference }.let {
-        database.statusReferenceDao().insertAll(it)
-    }
-    items
-        .groupBy { it.timeline.pagingKey }
-        .forEach { (pagingKey, rows) ->
-            val statusIds = rows.map { it.timeline.statusId }.distinct()
-            if (statusIds.isNotEmpty()) {
-                database.pagingTimelineDao().deletePresentationReferences(
-                    pagingKey = pagingKey,
-                    statusIds = statusIds,
-                )
-            }
+    val existingTimelineById = loadExistingTimeline(database = database, incoming = timelines)
+    items.forEach { item ->
+        item.references.forEach { reference ->
+            reference.status?.data?.let { status -> statusesById.getOrPut(status.id) { status } }
         }
-    items.flatMap { it.presentationReferences }.map { it.reference }.let {
-        database.pagingTimelineDao().insertPresentationReferences(it)
+        item.presentationReferences.forEach { reference ->
+            reference.status?.data?.let { status -> statusesById.getOrPut(status.id) { status } }
+        }
     }
-    val changedTimeline = loadChangedTimeline(database, items.map { it.timeline })
+    val statuses = statusesById.values.toList()
+    val statusChanges = loadChangedStatuses(database, statuses)
+    val usersByKey = LinkedHashMap<MicroBlogKey, UiProfile>()
+    statusChanges.statuses.forEach { status -> status.content.collectUsersInto(usersByKey) }
+    database.upsertUsers(usersByKey.values.map { it.toDbUser() })
+    if (statusChanges.statuses.isNotEmpty()) {
+        database.statusDao().insertAll(statusChanges.statuses)
+        statusChanges.dependencyBumpIds.chunked(DEPENDENCY_REVISION_BATCH_SIZE).forEach { statusIds ->
+            database.statusDao().bumpTimelineDependencies(statusIds)
+        }
+    }
+    val statusReferenceRootIds = HashSet<String>()
+    val presentationReferenceItems = ArrayList<DbPagingTimelineWithStatus>()
+    timelines.forEachIndexed { index, timeline ->
+        val existing = existingTimelineById[timeline._id]
+        if (existing?.statusReferenceHash != timeline.statusReferenceHash) {
+            statusReferenceRootIds += timeline.statusId
+        }
+        if (existing?.presentationReferenceHash != timeline.presentationReferenceHash) {
+            presentationReferenceItems += items[index]
+        }
+    }
+    syncStatusReferences(
+        database = database,
+        rootStatusIds = statusReferenceRootIds,
+        items = items,
+    )
+    syncPresentationReferences(
+        database = database,
+        items = presentationReferenceItems,
+    )
+    val changedTimeline = loadChangedTimeline(existingById = existingTimelineById, incoming = timelines)
     if (changedTimeline.isNotEmpty()) {
         database.pagingTimelineDao().insertAll(changedTimeline)
     }
 }
 
 private const val SQL_IN_BATCH_SIZE = 500
+private const val DEPENDENCY_REVISION_BATCH_SIZE = 300
 
 private suspend fun loadChangedStatuses(
     database: CacheDatabase,
     incoming: List<DbStatus>,
-): List<DbStatus> {
-    val existingByKey =
-        incoming
-            .groupBy { it.accountType }
-            .flatMap { (accountType, accountStatuses) ->
-                accountStatuses
-                    .map { it.statusKey }
-                    .distinct()
-                    .chunked(SQL_IN_BATCH_SIZE)
-                    .flatMap { chunk ->
-                        database.statusDao().getByKeys(statusKeys = chunk, accountType = accountType)
-                    }
-            }.associateBy { it.id }
-    return incoming.filter { status ->
-        existingByKey[status.id] != status
+): StatusChanges {
+    if (incoming.isEmpty()) {
+        return StatusChanges()
     }
+    val existingById =
+        incoming
+            .map { it.id }
+            .distinct()
+            .chunked(SQL_IN_BATCH_SIZE)
+            .flatMap { database.statusDao().getFingerprints(it) }
+            .associateBy { it.id }
+    val changed =
+        incoming.filter { status ->
+            val saved = existingById[status.id]
+            saved == null || saved.contentHash != status.contentHash || saved.renderHash != status.renderHash
+        }
+    val newIds = changed.mapNotNullTo(HashSet()) { status -> status.id.takeIf { it !in existingById } }
+    val restoredDependencyIds =
+        if (newIds.isEmpty()) {
+            emptySet()
+        } else {
+            database
+                .statusDao()
+                .getMissingTimelineDependencyStatusIds()
+                .mapNotNullTo(HashSet()) { row -> row.id.takeIf { it in newIds } }
+        }
+    return StatusChanges(
+        statuses = changed,
+        dependencyBumpIds = changed.mapNotNull { status -> status.id.takeIf { it in existingById } } + restoredDependencyIds,
+    )
 }
 
-private suspend fun loadChangedTimeline(
+private data class StatusChanges(
+    val statuses: List<DbStatus> = emptyList(),
+    val dependencyBumpIds: List<String> = emptyList(),
+)
+
+private suspend fun loadExistingTimeline(
     database: CacheDatabase,
     incoming: List<DbPagingTimeline>,
-): List<DbPagingTimeline> {
-    val existingByPair =
-        incoming
-            .groupBy { it.pagingKey }
-            .flatMap { (pagingKey, rows) ->
-                rows
-                    .map { it.statusId }
-                    .distinct()
-                    .chunked(SQL_IN_BATCH_SIZE)
-                    .flatMap { chunk ->
-                        database.pagingTimelineDao().getByPagingKeyAndStatusIds(
-                            pagingKey = pagingKey,
-                            statusIds = chunk,
-                        )
-                    }
-            }.associateBy { it.pagingKey to it.statusId }
-    return incoming.filter { timeline ->
-        existingByPair[timeline.pagingKey to timeline.statusId] != timeline
+): Map<String, DbPagingTimeline> =
+    incoming
+        .groupBy { it.pagingKey }
+        .flatMap { (pagingKey, rows) ->
+            rows
+                .map { it.statusId }
+                .distinct()
+                .chunked(SQL_IN_BATCH_SIZE)
+                .flatMap { chunk ->
+                    database.pagingTimelineDao().getByPagingKeyAndStatusIds(
+                        pagingKey = pagingKey,
+                        statusIds = chunk,
+                    )
+                }
+        }.associateBy { DbPagingTimeline.createId(pagingKey = it.pagingKey, statusId = it.statusId) }
+
+private fun loadChangedTimeline(
+    existingById: Map<String, DbPagingTimeline>,
+    incoming: List<DbPagingTimeline>,
+): List<DbPagingTimeline> =
+    incoming.mapNotNull { timeline ->
+        val existing = existingById[timeline._id]
+        when {
+            existing == null -> timeline
+            existing.hasSameStoredContentAs(timeline) -> null
+            else -> timeline.copy(_id = existing._id)
+        }
+    }
+
+private suspend fun syncStatusReferences(
+    database: CacheDatabase,
+    rootStatusIds: Set<String>,
+    items: List<DbPagingTimelineWithStatus>,
+) {
+    if (rootStatusIds.isEmpty()) {
+        return
+    }
+    val dao = database.statusReferenceDao()
+    val existing =
+        rootStatusIds
+            .chunked(SQL_IN_BATCH_SIZE)
+            .flatMap { dao.getByStatusIds(it) }
+    val incomingById = LinkedHashMap<String, DbStatusReference>()
+    items.forEach { item ->
+        item.references.forEach { referenceWithStatus ->
+            val reference = referenceWithStatus.reference
+            if (reference.statusId in rootStatusIds) {
+                incomingById[reference._id] = reference
+            }
+        }
+    }
+    val existingById = existing.associateBy { it._id }
+    val stale = existing.filter { it._id !in incomingById }
+    val changed =
+        incomingById.mapNotNull { (id, reference) ->
+            val saved = existingById[id]
+            when {
+                saved == null -> reference
+                saved.hasSameStoredContentAs(reference) -> null
+                else -> reference.copy(_id = saved._id)
+            }
+        }
+    if (stale.isNotEmpty()) {
+        dao.deleteItems(stale)
+    }
+    if (changed.isNotEmpty()) {
+        dao.insertAll(changed)
     }
 }
 
-private fun UiTimelineV2.usersInContent(): List<UiProfile> =
+private suspend fun syncPresentationReferences(
+    database: CacheDatabase,
+    items: List<DbPagingTimelineWithStatus>,
+) {
+    val dao = database.pagingTimelineDao()
+    items.groupBy { it.timeline.pagingKey }.forEach { (pagingKey, rows) ->
+        val statusIds = rows.map { it.timeline.statusId }.distinct()
+        if (statusIds.isEmpty()) {
+            return@forEach
+        }
+        val existing =
+            statusIds
+                .chunked(SQL_IN_BATCH_SIZE)
+                .flatMap { dao.getPresentationReferences(pagingKey = pagingKey, statusIds = it) }
+        val incomingById = LinkedHashMap<String, DbTimelineItemPresentationReference>()
+        rows.forEach { item ->
+            item.presentationReferences.forEach { reference ->
+                incomingById[reference.reference._id] = reference.reference
+            }
+        }
+        val existingById = existing.associateBy { it._id }
+        val stale = existing.filter { it._id !in incomingById }
+        val changed =
+            incomingById.mapNotNull { (id, reference) ->
+                val saved = existingById[id]
+                when {
+                    saved == null -> reference
+                    saved.hasSameStoredContentAs(reference) -> null
+                    else -> reference.copy(_id = saved._id)
+                }
+            }
+        if (stale.isNotEmpty()) {
+            dao.deletePresentationReferenceItems(stale)
+        }
+        if (changed.isNotEmpty()) {
+            dao.insertPresentationReferences(changed)
+        }
+    }
+}
+
+private fun DbStatusReference.hasSameStoredContentAs(other: DbStatusReference): Boolean =
+    referenceType == other.referenceType &&
+        statusId == other.statusId &&
+        referenceStatusId == other.referenceStatusId &&
+        referenceOrder == other.referenceOrder
+
+private fun DbTimelineItemPresentationReference.hasSameStoredContentAs(other: DbTimelineItemPresentationReference): Boolean =
+    pagingKey == other.pagingKey &&
+        statusId == other.statusId &&
+        referenceStatusId == other.referenceStatusId &&
+        presentationType == other.presentationType &&
+        referenceOrder == other.referenceOrder
+
+private fun DbPagingTimeline.hasSameStoredContentAs(other: DbPagingTimeline): Boolean =
+    pagingKey == other.pagingKey &&
+        statusId == other.statusId &&
+        sortId == other.sortId &&
+        message == other.message &&
+        messageRenderHash == other.messageRenderHash &&
+        statusReferenceHash == other.statusReferenceHash &&
+        presentationReferenceHash == other.presentationReferenceHash
+
+private fun UiTimelineV2.collectUsersInto(destination: MutableMap<MicroBlogKey, UiProfile>) {
     when (this) {
         is UiTimelineV2.Post -> {
-            listOfNotNull(user)
+            user?.addTo(destination)
         }
 
         is UiTimelineV2.TimelinePostItem -> {
-            post.usersInContent() +
-                listOfNotNull(presentation.message?.user) +
-                presentation.inlineParents.flatMap { it.usersInContent() } +
-                presentation.quotes.flatMap { it.usersInContent() } +
-                listOfNotNull(presentation.repost).flatMap { it.usersInContent() }
+            post.collectUsersInto(destination)
+            presentation.message?.user?.addTo(destination)
+            presentation.inlineParents.forEach { it.collectUsersInto(destination) }
+            presentation.quotes.forEach { it.collectUsersInto(destination) }
+            presentation.repost?.collectUsersInto(destination)
         }
 
         is UiTimelineV2.User -> {
-            listOfNotNull(value, message?.user)
+            value.addTo(destination)
+            message?.user?.addTo(destination)
         }
 
         is UiTimelineV2.UserList -> {
-            users +
-                listOfNotNull(message?.user) +
-                listOfNotNull(post).flatMap { it.usersInContent() }
+            users.forEach { it.addTo(destination) }
+            message?.user?.addTo(destination)
+            post?.collectUsersInto(destination)
         }
 
         else -> {
-            emptyList()
         }
     }
+}
+
+private fun UiProfile.addTo(destination: MutableMap<MicroBlogKey, UiProfile>) {
+    destination.getOrPut(key) { this }
+}

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/mapper/User.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/mapper/User.kt
@@ -2,8 +2,8 @@ package dev.dimension.flare.data.database.cache.mapper
 
 import dev.dimension.flare.data.database.cache.CacheDatabase
 import dev.dimension.flare.data.database.cache.model.DbUser
+import dev.dimension.flare.model.MicroBlogKey
 import dev.dimension.flare.ui.model.UiProfile
-import kotlinx.coroutines.flow.firstOrNull
 
 internal fun UiProfile.toDbUser(host: String = this.host ?: key.host) =
     DbUser(
@@ -22,15 +22,15 @@ internal suspend fun CacheDatabase.upsertUsers(users: List<DbUser>) {
     if (users.isEmpty()) {
         return
     }
-    val distinctUsers = users.distinctBy { it.userKey }
+    val distinctUsersByKey = LinkedHashMap<MicroBlogKey, DbUser>(users.size)
+    users.forEach { user -> distinctUsersByKey.getOrPut(user.userKey) { user } }
     val existingUsers =
-        userDao()
-            .findByKeys(distinctUsers.map { it.userKey })
-            .firstOrNull()
-            .orEmpty()
+        distinctUsersByKey.keys
+            .chunked(SQL_IN_BATCH_SIZE)
+            .flatMap { userDao().findByKeysOnce(it) }
             .associateBy { it.userKey }
     val changedUsers =
-        distinctUsers.mapNotNull { user ->
+        distinctUsersByKey.values.mapNotNull { user ->
             val existing = existingUsers[user.userKey]
             val merged = existing?.let { user.mergeWith(it) } ?: user
             if (merged == existing) {
@@ -44,6 +44,8 @@ internal suspend fun CacheDatabase.upsertUsers(users: List<DbUser>) {
     }
     userDao().insertAll(changedUsers)
 }
+
+private const val SQL_IN_BATCH_SIZE = 500
 
 private fun DbUser.mergeWith(existing: DbUser): DbUser =
     copy(

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/model/DbPagingTimeline.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/model/DbPagingTimeline.kt
@@ -12,7 +12,6 @@ import dev.dimension.flare.common.encodeProtobuf
 import dev.dimension.flare.model.ReferenceType
 import dev.dimension.flare.ui.model.UiTimelineV2
 import kotlin.time.Instant
-import kotlin.uuid.Uuid
 
 @Entity(
     indices = [
@@ -32,9 +31,25 @@ internal data class DbPagingTimeline(
     @ColumnInfo(typeAffinity = ColumnInfo.BLOB)
     val message: UiTimelineV2.Message? = null,
     val messageRenderHash: Int? = message?.renderHash,
+    val statusReferenceHash: Long = stableDatabaseHash("status-reference-set"),
+    val presentationReferenceHash: Long = stableDatabaseHash("presentation-reference-set"),
+    /**
+     * Monotonic cache revision bumped when this row's status, references, or translations change.
+     *
+     * Keeping the revision on the timeline row lets stable-prefix refreshes detect dependency
+     * changes without materializing every dependency row across the SQLite/Kotlin boundary.
+     */
+    val dependencyRevision: Long = 0,
     @PrimaryKey
-    val _id: String = Uuid.random().toString(),
-)
+    val _id: String = createId(pagingKey = pagingKey, statusId = statusId),
+) {
+    companion object {
+        fun createId(
+            pagingKey: String,
+            statusId: String,
+        ): String = stableDatabaseId("timeline", pagingKey, statusId)
+    }
+}
 
 @Entity(
     tableName = "timeline_item_presentation_reference",
@@ -51,6 +66,7 @@ internal data class DbPagingTimeline(
             ],
             unique = true,
         ),
+        Index(value = ["referenceStatusId"]),
     ],
 )
 internal data class DbTimelineItemPresentationReference(
@@ -61,7 +77,23 @@ internal data class DbTimelineItemPresentationReference(
     val referenceStatusId: String,
     val presentationType: DbTimelineItemPresentationType,
     val referenceOrder: Int = 0,
-)
+) {
+    companion object {
+        fun createId(
+            pagingKey: String,
+            statusId: String,
+            referenceStatusId: String,
+            presentationType: DbTimelineItemPresentationType,
+        ): String =
+            stableDatabaseId(
+                "presentation-reference",
+                pagingKey,
+                statusId,
+                presentationType.name,
+                referenceStatusId,
+            )
+    }
+}
 
 internal enum class DbTimelineItemPresentationType {
     InlineParent,
@@ -194,3 +226,48 @@ internal class StatusConverter {
     @ColumnTypeConverter
     fun toTimestamp(value: Long): Instant = Instant.fromEpochMilliseconds(value)
 }
+
+internal fun stableDatabaseId(
+    type: String,
+    vararg parts: String,
+): String =
+    buildString {
+        append(type)
+        parts.forEach { part ->
+            append('|')
+            append(part.length)
+            append(':')
+            append(part)
+        }
+    }
+
+internal fun stableDatabaseHash(
+    type: String,
+    vararg parts: String,
+): Long = stableDatabaseHash(type, parts.asIterable())
+
+/** Folds the stable id format directly, avoiding a temporary combined String. */
+internal fun stableDatabaseHash(
+    type: String,
+    parts: Iterable<String>,
+): Long {
+    var hash = FNV_1A_64_OFFSET_BASIS
+
+    fun add(value: String) {
+        value.forEach { character ->
+            hash = (hash xor character.code.toLong()) * FNV_1A_64_PRIME
+        }
+    }
+
+    add(type)
+    parts.forEach { part ->
+        add("|")
+        add(part.length.toString())
+        add(":")
+        add(part)
+    }
+    return hash
+}
+
+private const val FNV_1A_64_OFFSET_BASIS = -3750763034362895579L
+private const val FNV_1A_64_PRIME = 1099511628211L

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/model/DbStatus.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/model/DbStatus.kt
@@ -1,9 +1,13 @@
 package dev.dimension.flare.data.database.cache.model
 
 import androidx.room3.ColumnInfo
+import androidx.room3.ColumnTypeConverter
 import androidx.room3.Entity
+import androidx.room3.Ignore
 import androidx.room3.Index
 import androidx.room3.PrimaryKey
+import dev.dimension.flare.common.decodeProtobuf
+import dev.dimension.flare.common.encodeProtobuf
 import dev.dimension.flare.model.DbAccountType
 import dev.dimension.flare.model.MicroBlogKey
 import dev.dimension.flare.ui.model.UiTimelineV2
@@ -14,13 +18,53 @@ import dev.dimension.flare.ui.model.UiTimelineV2
 internal data class DbStatus(
     val statusKey: MicroBlogKey,
     val accountType: DbAccountType,
-    @ColumnInfo(typeAffinity = ColumnInfo.BLOB)
-    val content: UiTimelineV2,
+    @ColumnInfo(name = "content", typeAffinity = ColumnInfo.BLOB)
+    val storedContent: DbTimelineContent,
+    val contentHash: Long,
     val renderHash: Int,
     val text: String?, // For Searching
     @PrimaryKey
     val id: String = createId(accountType = accountType, statusKey = statusKey),
 ) {
+    @Ignore
+    constructor(
+        statusKey: MicroBlogKey,
+        accountType: DbAccountType,
+        content: UiTimelineV2,
+        renderHash: Int,
+        text: String?,
+        id: String = createId(accountType = accountType, statusKey = statusKey),
+    ) : this(
+        statusKey = statusKey,
+        accountType = accountType,
+        preparedContent = DbTimelineContent.encode(content),
+        renderHash = renderHash,
+        text = text,
+        id = id,
+    )
+
+    @Ignore
+    private constructor(
+        statusKey: MicroBlogKey,
+        accountType: DbAccountType,
+        preparedContent: DbTimelineContent,
+        renderHash: Int,
+        text: String?,
+        id: String,
+    ) : this(
+        statusKey = statusKey,
+        accountType = accountType,
+        storedContent = preparedContent,
+        contentHash = preparedContent.contentHash,
+        renderHash = renderHash,
+        text = text,
+        id = id,
+    )
+
+    @get:Ignore
+    val content: UiTimelineV2
+        get() = storedContent.value
+
     companion object {
         fun createId(
             accountType: DbAccountType,
@@ -28,3 +72,54 @@ internal data class DbStatus(
         ): String = "${accountType}_$statusKey"
     }
 }
+
+internal fun UiTimelineV2.databaseContentHash(): Long = encodeProtobuf<UiTimelineV2>().databaseContentHash()
+
+private fun ByteArray.databaseContentHash(): Long =
+    fold(FNV_1A_64_OFFSET_BASIS) { hash, byte ->
+        (hash xor (byte.toLong() and 0xffL)) * FNV_1A_64_PRIME
+    }
+
+internal class DbTimelineContent private constructor(
+    val value: UiTimelineV2,
+    private val encoded: ByteArray?,
+    val contentHash: Long,
+) {
+    override fun equals(other: Any?): Boolean = other is DbTimelineContent && value == other.value
+
+    override fun hashCode(): Int = value.hashCode()
+
+    companion object {
+        fun encode(value: UiTimelineV2): DbTimelineContent {
+            val encoded = value.encodeProtobuf<UiTimelineV2>()
+            return DbTimelineContent(
+                value = value,
+                encoded = encoded,
+                contentHash = encoded.databaseContentHash(),
+            )
+        }
+
+        fun decode(encoded: ByteArray): DbTimelineContent =
+            DbTimelineContent(
+                value = encoded.decodeProtobuf<UiTimelineV2>(),
+                // The decoded model is retained by the timeline cache; keeping the database
+                // blob here as well would duplicate every cached status payload in memory.
+                encoded = null,
+                // DbStatus.contentHash is read from its own numeric column.
+                contentHash = 0,
+            )
+
+        fun bytes(value: DbTimelineContent): ByteArray = value.encoded ?: value.value.encodeProtobuf<UiTimelineV2>()
+    }
+}
+
+internal class DbTimelineContentConverter {
+    @ColumnTypeConverter
+    fun fromTimelineContent(value: DbTimelineContent): ByteArray = DbTimelineContent.bytes(value)
+
+    @ColumnTypeConverter
+    fun toTimelineContent(value: ByteArray): DbTimelineContent = DbTimelineContent.decode(value)
+}
+
+private const val FNV_1A_64_OFFSET_BASIS = -3750763034362895579L
+private const val FNV_1A_64_PRIME = 1099511628211L

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/model/DbStatusReference.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/model/DbStatusReference.kt
@@ -21,6 +21,7 @@ import dev.dimension.flare.model.ReferenceType
             ],
             unique = true,
         ),
+        Index(value = ["referenceStatusId"]),
     ],
 )
 internal data class DbStatusReference(
@@ -33,4 +34,18 @@ internal data class DbStatusReference(
     val statusId: String,
     val referenceStatusId: String,
     val referenceOrder: Int = 0,
-)
+) {
+    companion object {
+        fun createId(
+            referenceType: ReferenceType,
+            statusId: String,
+            referenceStatusId: String,
+        ): String =
+            stableDatabaseId(
+                "status-reference",
+                statusId,
+                referenceType.name,
+                referenceStatusId,
+            )
+    }
+}

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/model/DbTranslation.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/model/DbTranslation.kt
@@ -33,6 +33,18 @@ internal data class DbTranslation(
     val statusReason: String? = null,
     val attemptCount: Int = 0,
     val updatedAt: Long,
+    /** Numeric payload revision used by the timeline cache's lightweight identity scan. */
+    val revision: Long =
+        stableDatabaseHash(
+            "translation-revision",
+            sourceHash,
+            status.name,
+            displayMode.name,
+            payload?.hashCode()?.toString().orEmpty(),
+            statusReason.orEmpty(),
+            attemptCount.toString(),
+            updatedAt.toString(),
+        ),
     @PrimaryKey
     val id: String = "${entityType.name}:$entityKey:$targetLanguage",
 )

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/datasource/microblog/MixedRemoteMediator.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/datasource/microblog/MixedRemoteMediator.kt
@@ -3,6 +3,7 @@ package dev.dimension.flare.data.datasource.microblog
 import androidx.paging.ExperimentalPagingApi
 import dev.dimension.flare.data.database.cache.CacheDatabase
 import dev.dimension.flare.data.database.cache.connect
+import dev.dimension.flare.data.database.cache.loadTimelinePage
 import dev.dimension.flare.data.database.cache.mapper.saveToDatabase
 import dev.dimension.flare.data.database.cache.model.DbPagingKey
 import dev.dimension.flare.data.database.cache.model.DbPagingTimelineWithStatus
@@ -165,13 +166,11 @@ internal class MixedRemoteMediator(
                                             PagingResult(endOfPaginationReached = true)
                                         }
                                     val stagedItems =
-                                        result.data.map { item ->
-                                            TimelinePagingMapper.toDb(
-                                                data = item,
-                                                pagingKey = state.source.stagingKey,
-                                                sortId = timeSortId(item),
-                                            )
-                                        }
+                                        TimelinePagingMapper.toDb(
+                                            data = result.data,
+                                            pagingKey = state.source.stagingKey,
+                                            sortIds = result.data.map { timeSortId(it) },
+                                        )
                                     TimeSubResponse(state, result, stagedItems)
                                 }
                             }.awaitAll()
@@ -233,7 +232,7 @@ internal class MixedRemoteMediator(
                 source = source,
                 pending =
                     ArrayDeque(
-                        database.pagingTimelineDao().getTimelinePage(
+                        database.loadTimelinePage(
                             pagingKey = source.stagingKey,
                             offset = 0,
                             limit = Int.MAX_VALUE,

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/datasource/microblog/paging/TimelineDbPageLoader.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/datasource/microblog/paging/TimelineDbPageLoader.kt
@@ -3,8 +3,17 @@ package dev.dimension.flare.data.datasource.microblog.paging
 import dev.dimension.flare.common.PlatformDispatchers
 import dev.dimension.flare.data.database.cache.CacheDatabase
 import dev.dimension.flare.data.database.cache.dao.DbTimelinePageIdentity
-import dev.dimension.flare.data.database.cache.dao.PagingTimelineDao
+import dev.dimension.flare.data.database.cache.dao.DbTimelinePageIdentityRoot
+import dev.dimension.flare.data.database.cache.loadTimelineItems
+import dev.dimension.flare.data.database.cache.loadTimelinePageIdentities
 import dev.dimension.flare.data.database.cache.model.DbPagingTimelineWithStatus
+import dev.dimension.flare.data.database.cache.model.DbStatus
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.persistentHashMapOf
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
@@ -13,112 +22,283 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
+/**
+ * Keeps the logical prefix already exposed to Paging loaded across invalidations.
+ *
+ * A smaller refresh request cannot evict its tail, and rows inserted above the prefix extend it
+ * through the previously loaded last row. Database deletions can still make the prefix shorter.
+ */
 internal class TimelineDbPageCache {
     private val mutex = Mutex()
     private var snapshot = Snapshot()
+    private var generation = 0L
 
     suspend fun hasCurrentWindowChanged(
-        dao: PagingTimelineDao,
+        database: CacheDatabase,
         pagingKey: String,
-    ): Boolean =
-        mutex.withLock {
-            if (!snapshot.loaded) {
-                return@withLock true
+        changedTables: Set<String>? = null,
+    ): Boolean {
+        val state =
+            mutex.withLock {
+                if (!snapshot.loaded) {
+                    return true
+                }
+                CacheState(
+                    generation = generation,
+                    snapshot = snapshot,
+                )
             }
-            val identities =
-                dao.getTimelinePageIdentities(
+        val dependencyTablesChanged =
+            changedTables == null ||
+                changedTables.any { table -> !table.equals(TIMELINE_TABLE, ignoreCase = true) }
+        val identities =
+            if (dependencyTablesChanged) {
+                database.loadTimelinePageIdentities(
                     pagingKey = pagingKey,
                     offset = 0,
-                    limit = snapshot.identities.size + 1,
+                    limit = state.snapshot.identities.size + 1,
                 )
-            val currentWindow = identities.take(snapshot.identities.size)
-            val nextIdentity = identities.getOrNull(snapshot.identities.size)
-            currentWindow != snapshot.identities || nextIdentity != snapshot.nextIdentity
+            } else {
+                null
+            }
+        val roots =
+            if (identities == null) {
+                database
+                    .pagingTimelineDao()
+                    .getTimelinePageIdentityRoots(
+                        pagingKey = pagingKey,
+                        offset = 0,
+                        limit = state.snapshot.identities.size + 1,
+                    )
+            } else {
+                null
+            }
+        return mutex.withLock {
+            if (generation != state.generation) {
+                return@withLock true
+            }
+            if (identities != null) {
+                val currentWindow = identities.take(state.snapshot.identities.size)
+                val nextIdentity = identities.getOrNull(state.snapshot.identities.size)
+                currentWindow != state.snapshot.identities || nextIdentity != state.snapshot.nextIdentity
+            } else {
+                checkNotNull(roots)
+                val currentWindow = roots.take(state.snapshot.identities.size)
+                val nextRoot = roots.getOrNull(state.snapshot.identities.size)
+                currentWindow.size != state.snapshot.identities.size ||
+                    currentWindow.indices.any { index ->
+                        !currentWindow[index].hasSameStructureAs(state.snapshot.identities[index])
+                    } ||
+                    !nextRoot.hasSameStructureAs(state.snapshot.nextIdentity)
+            }
         }
+    }
 
     suspend fun load(
-        dao: PagingTimelineDao,
+        database: CacheDatabase,
         pagingKey: String,
         offset: Int,
         limit: Int,
-    ): List<DbPagingTimelineWithStatus> =
-        mutex.withLock {
-            val identityRows =
-                dao.getTimelinePageIdentities(
-                    pagingKey = pagingKey,
-                    offset = offset,
-                    limit = limit + 1,
-                )
-            val pageIdentities = identityRows.take(limit)
-            if (pageIdentities.isEmpty()) {
-                if (offset == 0) {
-                    val nextIdentity = identityRows.firstOrNull()
-                    snapshot =
-                        Snapshot(
-                            loaded = true,
-                            nextIdentity = nextIdentity,
-                        )
+    ): List<DbPagingTimelineWithStatus> {
+        while (true) {
+            val state =
+                mutex.withLock {
+                    CacheState(
+                        generation = generation,
+                        snapshot = snapshot,
+                    )
                 }
-                return@withLock emptyList()
-            }
-
-            if (offset == 0) {
-                val reusablePrefix = snapshot.reusablePrefix(pageIdentities)
-                val fetchedLimit = pageIdentities.size - reusablePrefix
-                val fetchedData =
-                    if (fetchedLimit > 0) {
-                        dao.getTimelinePage(
-                            pagingKey = pagingKey,
-                            offset = reusablePrefix,
-                            limit = fetchedLimit,
-                        )
-                    } else {
-                        emptyList()
-                    }
-                val data = snapshot.data.take(reusablePrefix) + fetchedData
-                snapshot =
-                    Snapshot(
-                        loaded = true,
-                        identities = pageIdentities.take(data.size),
-                        data = data,
-                        nextIdentity = identityRows.getOrNull(data.size),
-                    )
-                return@withLock data
-            }
-
-            val data =
-                dao.getTimelinePage(
+            val retainedPrefixLimit =
+                if (offset == 0) {
+                    state.snapshot.identities.lastOrNull()?.let { lastIdentity ->
+                        database
+                            .pagingTimelineDao()
+                            .getTimelinePrefixLengthThroughStatus(
+                                pagingKey = pagingKey,
+                                statusId = lastIdentity.statusId,
+                            )
+                    } ?: 0
+                } else {
+                    0
+                }
+            val requestedLimit =
+                if (offset == 0) {
+                    maxOf(limit, state.snapshot.data.size, retainedPrefixLimit)
+                } else {
+                    limit
+                }
+            val identityRows =
+                database.loadTimelinePageIdentities(
                     pagingKey = pagingKey,
                     offset = offset,
-                    limit = limit,
+                    limit = requestedLimit + 1,
                 )
-            if (snapshot.data.size == offset && data.size == pageIdentities.size) {
-                snapshot =
-                    Snapshot(
-                        loaded = true,
-                        identities = snapshot.identities + pageIdentities,
-                        data = snapshot.data + data,
-                        nextIdentity = identityRows.getOrNull(pageIdentities.size),
-                    )
+            val pageIdentities = identityRows.take(requestedLimit)
+            val unchangedData =
+                if (offset == 0 && pageIdentities == state.snapshot.identities &&
+                    identityRows.getOrNull(pageIdentities.size) == state.snapshot.nextIdentity
+                ) {
+                    mutex.withLock {
+                        state.snapshot.data.takeIf { generation == state.generation }
+                    }
+                } else {
+                    null
+                }
+            if (unchangedData != null) {
+                return unchangedData
             }
-            data
+            val resolved =
+                resolve(
+                    database = database,
+                    pagingKey = pagingKey,
+                    previous = state.snapshot.entries,
+                    reusableStatuses = state.snapshot.statuses,
+                    identities = pageIdentities,
+                )
+            val committed =
+                mutex.withLock {
+                    if (generation != state.generation) {
+                        return@withLock null
+                    }
+                    val data = resolved.map { it.data }.toPersistentList()
+                    if (offset == 0) {
+                        snapshot =
+                            Snapshot(
+                                loaded = true,
+                                identities = resolved.map { it.identity }.toPersistentList(),
+                                data = data,
+                                entries = resolved.associateBy { it.identity.statusId }.toPersistentMap(),
+                                statuses = resolved.collectStatuses().toPersistentMap(),
+                                nextIdentity = identityRows.getOrNull(pageIdentities.size),
+                            )
+                    } else if (
+                        snapshot.data.size == offset &&
+                        resolved.size == pageIdentities.size
+                    ) {
+                        snapshot =
+                            snapshot.copy(
+                                loaded = true,
+                                identities = snapshot.identities.addingAll(resolved.map { it.identity }),
+                                data = snapshot.data.addingAll(data),
+                                entries = snapshot.entries.puttingAll(resolved.associateBy { it.identity.statusId }),
+                                statuses = snapshot.statuses.puttingAll(resolved.collectStatuses()),
+                                nextIdentity = identityRows.getOrNull(pageIdentities.size),
+                            )
+                    }
+                    generation++
+                    data
+                }
+            if (committed != null) {
+                return committed
+            }
+        }
+    }
+
+    private suspend fun resolve(
+        database: CacheDatabase,
+        pagingKey: String,
+        previous: PersistentMap<String, CachedEntry>,
+        reusableStatuses: PersistentMap<String, DbStatus>,
+        identities: List<DbTimelinePageIdentity>,
+    ): List<CachedEntry> {
+        if (identities.isEmpty()) {
+            return emptyList()
+        }
+        val missingStatusIds =
+            identities.mapNotNull { identity ->
+                if (previous[identity.statusId]?.identity?.hasSamePayloadAs(identity) == true) {
+                    null
+                } else {
+                    identity.statusId
+                }
+            }
+        val fetchedById =
+            database
+                .loadTimelineItems(
+                    pagingKey = pagingKey,
+                    statusIds = missingStatusIds,
+                    reusableStatuses = reusableStatuses,
+                ).associateBy { it.timeline.statusId }
+        return identities.mapNotNull { identity ->
+            val cached = previous[identity.statusId]
+            val data =
+                if (cached != null && cached.identity.hasSamePayloadAs(identity)) {
+                    cached.data.withSortId(identity.sortId)
+                } else {
+                    fetchedById[identity.statusId]
+                }
+            data?.let { CachedEntry(identity = identity, data = it) }
+        }
+    }
+
+    private fun DbPagingTimelineWithStatus.withSortId(sortId: Long): DbPagingTimelineWithStatus =
+        if (timeline.sortId == sortId) {
+            this
+        } else {
+            copy(timeline = timeline.copy(sortId = sortId))
+        }
+
+    private fun List<CachedEntry>.collectStatuses(): Map<String, DbStatus> {
+        val result = LinkedHashMap<String, DbStatus>(size * 2)
+        forEach { entry ->
+            val item = entry.data
+            result[item.statusData.id] = item.statusData
+            item.references.forEach { reference ->
+                reference.status?.data?.let { result[it.id] = it }
+            }
+            item.presentationReferences.forEach { reference ->
+                reference.status?.data?.let { result[it.id] = it }
+            }
+        }
+        return result
+    }
+
+    private fun DbTimelinePageIdentity.hasSamePayloadAs(other: DbTimelinePageIdentity): Boolean =
+        statusId == other.statusId &&
+            rootContentHash == other.rootContentHash &&
+            messageRenderHash == other.messageRenderHash &&
+            statusReferenceHash == other.statusReferenceHash &&
+            presentationReferenceHash == other.presentationReferenceHash &&
+            dependencyCount == other.dependencyCount &&
+            dependencyRevision == other.dependencyRevision
+
+    private fun DbTimelinePageIdentityRoot?.hasSameStructureAs(other: DbTimelinePageIdentity?): Boolean =
+        when {
+            this == null || other == null -> {
+                this == null && other == null
+            }
+
+            else -> {
+                statusId == other.statusId &&
+                    sortId == other.sortId &&
+                    rootContentHash == other.rootContentHash &&
+                    messageRenderHash == other.messageRenderHash &&
+                    statusReferenceHash == other.statusReferenceHash &&
+                    presentationReferenceHash == other.presentationReferenceHash
+            }
         }
 
     private data class Snapshot(
         val loaded: Boolean = false,
-        val identities: List<DbTimelinePageIdentity> = emptyList(),
-        val data: List<DbPagingTimelineWithStatus> = emptyList(),
+        val identities: PersistentList<DbTimelinePageIdentity> = persistentListOf(),
+        val data: PersistentList<DbPagingTimelineWithStatus> = persistentListOf(),
+        val entries: PersistentMap<String, CachedEntry> = persistentHashMapOf(),
+        val statuses: PersistentMap<String, DbStatus> = persistentHashMapOf(),
         val nextIdentity: DbTimelinePageIdentity? = null,
-    ) {
-        fun reusablePrefix(newIdentities: List<DbTimelinePageIdentity>): Int {
-            val max = minOf(identities.size, data.size, newIdentities.size)
-            for (index in 0 until max) {
-                if (identities[index] != newIdentities[index]) {
-                    return index
-                }
-            }
-            return max
-        }
+    )
+
+    private data class CachedEntry(
+        val identity: DbTimelinePageIdentity,
+        val data: DbPagingTimelineWithStatus,
+    )
+
+    private data class CacheState(
+        val generation: Long,
+        val snapshot: Snapshot,
+    )
+
+    private companion object {
+        const val TIMELINE_TABLE = "DbPagingTimeline"
     }
 }
 
@@ -132,7 +312,7 @@ internal class TimelineDbPageLoader(
         limit: Int,
     ): List<DbPagingTimelineWithStatus> =
         pageCache.load(
-            dao = database.pagingTimelineDao(),
+            database = database,
             pagingKey = pagingKey,
             offset = offset,
             limit = limit,
@@ -142,7 +322,6 @@ internal class TimelineDbPageLoader(
         val ready = CompletableDeferred<Unit>()
         val job =
             CoroutineScope(PlatformDispatchers.IO).launch(start = CoroutineStart.UNDISPATCHED) {
-                val dao = database.pagingTimelineDao()
                 database
                     .invalidationTracker
                     .createFlow(
@@ -152,14 +331,15 @@ internal class TimelineDbPageLoader(
                         "timeline_item_presentation_reference",
                         "DbTranslation",
                         emitInitialState = true,
-                    ).collect {
+                    ).collect { changedTables ->
                         if (ready.complete(Unit)) {
                             return@collect
                         }
                         val currentWindowChanged =
                             pageCache.hasCurrentWindowChanged(
-                                dao = dao,
+                                database = database,
                                 pagingKey = pagingKey,
+                                changedTables = changedTables,
                             )
                         if (!currentWindowChanged) {
                             return@collect

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/datasource/microblog/paging/TimelinePagingMapper.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/datasource/microblog/paging/TimelinePagingMapper.kt
@@ -13,24 +13,95 @@ import dev.dimension.flare.data.database.cache.model.DbTimelineItemPresentationR
 import dev.dimension.flare.data.database.cache.model.DbTimelineItemPresentationType
 import dev.dimension.flare.data.database.cache.model.TranslationDisplayOptions
 import dev.dimension.flare.data.database.cache.model.applyTranslation
+import dev.dimension.flare.data.database.cache.model.stableDatabaseHash
 import dev.dimension.flare.model.DbAccountType
 import dev.dimension.flare.model.ReferenceType
 import dev.dimension.flare.ui.model.UiTimelineV2
 import dev.dimension.flare.ui.model.asTimelinePostItem
 import dev.dimension.flare.ui.model.withItemKey
 import kotlinx.collections.immutable.toImmutableList
-import kotlin.uuid.Uuid
 
 internal object TimelinePagingMapper {
     suspend fun toDb(
         data: UiTimelineV2,
         pagingKey: String,
         sortId: Long? = null,
+    ): DbPagingTimelineWithStatus =
+        toDb(
+            data = data,
+            root = data.rootTimelineForDatabase(),
+            pagingKey = pagingKey,
+            sortId = sortId,
+            context = MappingContext(),
+        )
+
+    suspend fun toDb(
+        data: List<UiTimelineV2>,
+        pagingKey: String,
+        sortIds: List<Long?> = emptyList(),
+    ): List<DbPagingTimelineWithStatus> {
+        require(sortIds.isEmpty() || sortIds.size == data.size) {
+            "sortIds must be empty or have the same size as data"
+        }
+        val context = MappingContext()
+        val roots = data.map { it.rootTimelineForDatabase() }
+        // Roots win when the same status also appears as another row's presentation reference.
+        roots.forEach(context::statusForTimeline)
+        return data.mapIndexed { index, item ->
+            toDb(
+                data = item,
+                root = roots[index],
+                pagingKey = pagingKey,
+                sortId = sortIds.getOrNull(index),
+                context = context,
+            )
+        }
+    }
+
+    private suspend fun toDb(
+        data: UiTimelineV2,
+        root: UiTimelineV2,
+        pagingKey: String,
+        sortId: Long?,
+        context: MappingContext,
     ): DbPagingTimelineWithStatus {
-        val root = data.rootTimelineForDatabase()
         val timelineItem = data.asTimelinePostItem()
         val presentation = timelineItem?.presentation
-        val rootStatus = uiTimelineToDbStatusWithUser(root)
+        val rootStatus = context.statusForTimeline(root)
+        val presentationReferences =
+            when {
+                root is UiTimelineV2.Post && presentation != null -> {
+                    collectPresentationReferences(
+                        pagingKey = pagingKey,
+                        rootStatusId = rootStatus.data.id,
+                        presentation = presentation,
+                        context = context,
+                    )
+                }
+
+                else -> {
+                    emptyList()
+                }
+            }
+        val statusReferences =
+            when (root) {
+                is UiTimelineV2.Post -> {
+                    collectPostReferences(
+                        root = root,
+                        presentation = presentation,
+                        rootStatusId = rootStatus.data.id,
+                        presentationReferences = presentationReferences,
+                    )
+                }
+
+                is UiTimelineV2.UserList -> {
+                    collectUserListReferences(root, rootStatus.data.id, context)
+                }
+
+                else -> {
+                    emptyList()
+                }
+            }
         return DbPagingTimelineWithStatus(
             timeline =
                 DbPagingTimeline(
@@ -38,31 +109,15 @@ internal object TimelinePagingMapper {
                     statusId = rootStatus.data.id,
                     sortId = sortId ?: SnowflakeIdGenerator.nextId(),
                     message = presentation?.message,
+                    statusReferenceHash = statusReferences.statusReferenceStorageHash(),
+                    presentationReferenceHash = presentationReferences.presentationReferenceStorageHash(),
                 ),
             status =
                 DbStatusWithReference(
                     status = rootStatus,
-                    references =
-                        when (root) {
-                            is UiTimelineV2.Post -> collectPostReferences(root, presentation, rootStatus.data.id)
-                            is UiTimelineV2.UserList -> collectUserListReferences(root, rootStatus.data.id)
-                            else -> emptyList()
-                        },
+                    references = statusReferences,
                 ),
-            presentationReferences =
-                when {
-                    root is UiTimelineV2.Post && presentation != null -> {
-                        collectPresentationReferences(
-                            pagingKey = pagingKey,
-                            rootStatusId = rootStatus.data.id,
-                            presentation = presentation,
-                        )
-                    }
-
-                    else -> {
-                        emptyList()
-                    }
-                },
+            presentationReferences = presentationReferences,
         )
     }
 
@@ -73,7 +128,8 @@ internal object TimelinePagingMapper {
     ): UiTimelineV2 {
         val root =
             toUi(
-                item = item.status,
+                status = DbStatusWithUser(data = item.statusData, translations = item.statusTranslations),
+                references = item.references,
                 pagingKey = pagingKey,
                 translationDisplayOptions = translationDisplayOptions,
             )
@@ -86,7 +142,7 @@ internal object TimelinePagingMapper {
                         pagingKey = pagingKey,
                         translationDisplayOptions = translationDisplayOptions,
                     ),
-                itemKey = "${pagingKey}_${item.status.status.data.id}",
+                itemKey = "${pagingKey}_${item.statusData.id}",
             )
         } else {
             root
@@ -97,10 +153,23 @@ internal object TimelinePagingMapper {
         item: DbStatusWithReference,
         pagingKey: String,
         translationDisplayOptions: TranslationDisplayOptions,
+    ): UiTimelineV2 =
+        toUi(
+            status = item.status,
+            references = item.references,
+            pagingKey = pagingKey,
+            translationDisplayOptions = translationDisplayOptions,
+        )
+
+    private fun toUi(
+        status: DbStatusWithUser,
+        references: List<DbStatusReferenceWithStatus>,
+        pagingKey: String,
+        translationDisplayOptions: TranslationDisplayOptions,
     ): UiTimelineV2 {
         val root =
             dbStatusWithUserToUiTimeline(
-                data = item.status,
+                data = status,
                 pagingKey = pagingKey,
                 translationDisplayOptions = translationDisplayOptions,
             )
@@ -111,7 +180,7 @@ internal object TimelinePagingMapper {
 
             is UiTimelineV2.UserList -> {
                 val references =
-                    item.references
+                    references
                         .sortedBy { it.reference.referenceOrder }
                         .mapNotNull { reference ->
                             reference.status?.let {
@@ -138,35 +207,31 @@ internal object TimelinePagingMapper {
         pagingKey: String,
         translationDisplayOptions: TranslationDisplayOptions,
     ): UiTimelineV2.PostPresentation {
-        val references =
-            item.presentationReferences
-                .sortedBy { it.reference.referenceOrder }
-                .mapNotNull { reference ->
+        val inlineParents = ArrayList<UiTimelineV2.Post>()
+        val quotes = ArrayList<UiTimelineV2.Post>()
+        var repost: UiTimelineV2.Post? = null
+        item.presentationReferences
+            .sortedBy { it.reference.referenceOrder }
+            .forEach { reference ->
+                val post =
                     reference.status?.let {
-                        reference.reference.presentationType to
-                            dbStatusWithUserToUiTimeline(
-                                data = it,
-                                pagingKey = pagingKey,
-                                translationDisplayOptions = translationDisplayOptions,
-                            ) as? UiTimelineV2.Post
-                    }
+                        dbStatusWithUserToUiTimeline(
+                            data = it,
+                            pagingKey = pagingKey,
+                            translationDisplayOptions = translationDisplayOptions,
+                        ) as? UiTimelineV2.Post
+                    } ?: return@forEach
+                when (reference.reference.presentationType) {
+                    DbTimelineItemPresentationType.InlineParent -> inlineParents += post
+                    DbTimelineItemPresentationType.Quote -> quotes += post
+                    DbTimelineItemPresentationType.Repost -> if (repost == null) repost = post
                 }
+            }
         return UiTimelineV2.PostPresentation(
             message = item.timeline.message,
-            inlineParents =
-                references
-                    .filter { it.first == DbTimelineItemPresentationType.InlineParent }
-                    .mapNotNull { it.second }
-                    .toImmutableList(),
-            quotes =
-                references
-                    .filter { it.first == DbTimelineItemPresentationType.Quote }
-                    .mapNotNull { it.second }
-                    .toImmutableList(),
-            repost =
-                references
-                    .firstOrNull { it.first == DbTimelineItemPresentationType.Repost }
-                    ?.second,
+            inlineParents = inlineParents.toImmutableList(),
+            quotes = quotes.toImmutableList(),
+            repost = repost,
         )
     }
 
@@ -185,12 +250,13 @@ internal object TimelinePagingMapper {
     private fun collectUserListReferences(
         data: UiTimelineV2.UserList,
         rootStatusId: String,
+        context: MappingContext,
     ): List<DbStatusReferenceWithStatus> =
         data.post
             ?.let {
                 listOf(
                     dbStatusReferenceWithStatus(
-                        post = it,
+                        status = context.statusForPost(it),
                         referenceType = ReferenceType.Quote,
                         rootStatusId = rootStatusId,
                         referenceOrder = 0,
@@ -202,32 +268,36 @@ internal object TimelinePagingMapper {
         root: UiTimelineV2.Post,
         presentation: UiTimelineV2.PostPresentation?,
         rootStatusId: String,
+        presentationReferences: List<DbTimelineItemPresentationReferenceWithStatus>,
     ): List<DbStatusReferenceWithStatus> {
-        val presentationPosts =
-            buildMap {
-                presentation?.quotes?.forEach {
-                    put(ReferenceType.Quote to it.statusKey, it)
-                }
-                presentation?.repost?.let {
-                    put(ReferenceType.Retweet to it.statusKey, it)
-                }
-            }
+        val presentationStatuses =
+            presentationReferences
+                .mapNotNull { reference ->
+                    val referenceType =
+                        when (reference.reference.presentationType) {
+                            DbTimelineItemPresentationType.Quote -> ReferenceType.Quote
+                            DbTimelineItemPresentationType.Repost -> ReferenceType.Retweet
+                            DbTimelineItemPresentationType.InlineParent -> null
+                        }
+                    val status = reference.status
+                    if (referenceType == null || status == null) {
+                        null
+                    } else {
+                        (referenceType to reference.reference.referenceStatusId) to status
+                    }
+                }.toMap()
         val semanticReferences =
             (
                 root.references +
-                    presentationPosts.map { (key, _) ->
-                        UiTimelineV2.Post.Reference(
-                            statusKey = key.second,
-                            type = key.first,
-                        )
-                    }
+                    presentation.orEmptySemanticReferences()
             ).distinctBy { it.type to it.statusKey }
         return semanticReferences
             .mapIndexed { index, reference ->
-                val post = presentationPosts[reference.type to reference.statusKey]
-                if (post != null) {
+                val referenceStatusId = DbStatus.createId(root.accountType as DbAccountType, reference.statusKey)
+                val status = presentationStatuses[reference.type to referenceStatusId]
+                if (status != null) {
                     dbStatusReferenceWithStatus(
-                        post = post,
+                        status = status,
                         referenceType = reference.type,
                         rootStatusId = rootStatusId,
                         referenceOrder = index,
@@ -245,21 +315,79 @@ internal object TimelinePagingMapper {
             }
     }
 
+    private fun UiTimelineV2.PostPresentation?.orEmptySemanticReferences(): List<UiTimelineV2.Post.Reference> =
+        buildList {
+            this@orEmptySemanticReferences?.quotes?.forEach {
+                add(UiTimelineV2.Post.Reference(statusKey = it.statusKey, type = ReferenceType.Quote))
+            }
+            this@orEmptySemanticReferences?.repost?.let {
+                add(UiTimelineV2.Post.Reference(statusKey = it.statusKey, type = ReferenceType.Retweet))
+            }
+        }
+
+    private fun List<DbStatusReferenceWithStatus>.statusReferenceStorageHash(): Long {
+        val sorted = sortedWith(compareBy({ it.reference.referenceOrder }, { it.reference._id }))
+        val parts = ArrayList<String>(sorted.size * 2)
+        sorted.forEach { item ->
+            parts += item.reference._id
+            parts += item.reference.referenceOrder.toString()
+        }
+        return stableDatabaseHash("status-reference-set", parts)
+    }
+
+    private fun List<DbTimelineItemPresentationReferenceWithStatus>.presentationReferenceStorageHash(): Long {
+        val sorted = sortedWith(compareBy({ it.reference.referenceOrder }, { it.reference._id }))
+        val parts = ArrayList<String>(sorted.size * 2)
+        sorted.forEach { item ->
+            parts += item.reference._id
+            parts += item.reference.referenceOrder.toString()
+        }
+        return stableDatabaseHash("presentation-reference-set", parts)
+    }
+
     private fun collectPresentationReferences(
         pagingKey: String,
         rootStatusId: String,
         presentation: UiTimelineV2.PostPresentation,
+        context: MappingContext,
     ): List<DbTimelineItemPresentationReferenceWithStatus> {
         var order = 0
         return buildList {
             presentation.inlineParents.forEach { post ->
-                add(presentationReferenceWithStatus(pagingKey, rootStatusId, post, DbTimelineItemPresentationType.InlineParent, order++))
+                add(
+                    presentationReferenceWithStatus(
+                        pagingKey,
+                        rootStatusId,
+                        post,
+                        DbTimelineItemPresentationType.InlineParent,
+                        order++,
+                        context,
+                    ),
+                )
             }
             presentation.quotes.forEach { post ->
-                add(presentationReferenceWithStatus(pagingKey, rootStatusId, post, DbTimelineItemPresentationType.Quote, order++))
+                add(
+                    presentationReferenceWithStatus(
+                        pagingKey,
+                        rootStatusId,
+                        post,
+                        DbTimelineItemPresentationType.Quote,
+                        order++,
+                        context,
+                    ),
+                )
             }
             presentation.repost?.let { post ->
-                add(presentationReferenceWithStatus(pagingKey, rootStatusId, post, DbTimelineItemPresentationType.Repost, order++))
+                add(
+                    presentationReferenceWithStatus(
+                        pagingKey,
+                        rootStatusId,
+                        post,
+                        DbTimelineItemPresentationType.Repost,
+                        order++,
+                        context,
+                    ),
+                )
             }
         }.distinctBy {
             it.reference.presentationType to it.reference.referenceStatusId
@@ -267,7 +395,7 @@ internal object TimelinePagingMapper {
     }
 
     private fun dbStatusReferenceWithStatus(
-        post: UiTimelineV2.Post,
+        status: DbStatusWithUser,
         referenceType: ReferenceType,
         rootStatusId: String,
         referenceOrder: Int,
@@ -276,11 +404,16 @@ internal object TimelinePagingMapper {
             DbStatusReference(
                 referenceType = referenceType,
                 statusId = rootStatusId,
-                referenceStatusId = DbStatus.createId(post.accountType as DbAccountType, post.statusKey),
+                referenceStatusId = status.data.id,
                 referenceOrder = referenceOrder,
-                _id = Uuid.random().toString(),
+                _id =
+                    DbStatusReference.createId(
+                        referenceType = referenceType,
+                        statusId = rootStatusId,
+                        referenceStatusId = status.data.id,
+                    ),
             ),
-        status = uiTimelineToDbStatusWithUser(post.normalizedPost()),
+        status = status,
     )
 
     private fun dbStatusReferenceWithStatus(
@@ -295,7 +428,12 @@ internal object TimelinePagingMapper {
                 statusId = rootStatusId,
                 referenceStatusId = DbStatus.createId(accountType, reference.statusKey),
                 referenceOrder = referenceOrder,
-                _id = Uuid.random().toString(),
+                _id =
+                    DbStatusReference.createId(
+                        referenceType = reference.type,
+                        statusId = rootStatusId,
+                        referenceStatusId = DbStatus.createId(accountType, reference.statusKey),
+                    ),
             ),
         status = null,
     )
@@ -306,18 +444,28 @@ internal object TimelinePagingMapper {
         post: UiTimelineV2.Post,
         type: DbTimelineItemPresentationType,
         referenceOrder: Int,
-    ) = DbTimelineItemPresentationReferenceWithStatus(
-        reference =
-            DbTimelineItemPresentationReference(
-                pagingKey = pagingKey,
-                statusId = rootStatusId,
-                referenceStatusId = DbStatus.createId(post.accountType as DbAccountType, post.statusKey),
-                presentationType = type,
-                referenceOrder = referenceOrder,
-                _id = Uuid.random().toString(),
-            ),
-        status = uiTimelineToDbStatusWithUser(post.normalizedPost()),
-    )
+        context: MappingContext,
+    ): DbTimelineItemPresentationReferenceWithStatus {
+        val status = context.statusForPost(post)
+        return DbTimelineItemPresentationReferenceWithStatus(
+            reference =
+                DbTimelineItemPresentationReference(
+                    pagingKey = pagingKey,
+                    statusId = rootStatusId,
+                    referenceStatusId = status.data.id,
+                    presentationType = type,
+                    referenceOrder = referenceOrder,
+                    _id =
+                        DbTimelineItemPresentationReference.createId(
+                            pagingKey = pagingKey,
+                            statusId = rootStatusId,
+                            referenceStatusId = status.data.id,
+                            presentationType = type,
+                        ),
+                ),
+            status = status,
+        )
+    }
 
     private fun uiTimelineToDbStatusWithUser(data: UiTimelineV2): DbStatusWithUser =
         DbStatusWithUser(
@@ -330,6 +478,20 @@ internal object TimelinePagingMapper {
                     text = data.searchText,
                 ),
         )
+
+    private class MappingContext {
+        private val statusById = HashMap<String, DbStatusWithUser>()
+
+        fun statusForTimeline(data: UiTimelineV2): DbStatusWithUser {
+            val id = DbStatus.createId(data.accountType as DbAccountType, data.statusKey)
+            return statusById.getOrPut(id) { uiTimelineToDbStatusWithUser(data) }
+        }
+
+        fun statusForPost(data: UiTimelineV2.Post): DbStatusWithUser {
+            val id = DbStatus.createId(data.accountType as DbAccountType, data.statusKey)
+            return statusById.getOrPut(id) { uiTimelineToDbStatusWithUser(data.normalizedPost()) }
+        }
+    }
 
     private fun dbStatusWithUserToUiTimeline(
         data: DbStatusWithUser,

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/datasource/microblog/paging/TimelineRemoteMediator.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/datasource/microblog/paging/TimelineRemoteMediator.kt
@@ -86,14 +86,14 @@ internal class TimelineRemoteMediator(
                 pageSize = pageSize,
                 request = request,
             )
+        val sortIdProvider = loader as? SortIdProvider
+        val sortIds = result.data.map { sortIdProvider?.sortId(it) }
         val data =
-            result.data.map {
-                TimelinePagingMapper.toDb(
-                    data = it,
-                    pagingKey = pagingKey,
-                    sortId = (loader as? SortIdProvider)?.sortId(it),
-                )
-            }
+            TimelinePagingMapper.toDb(
+                data = result.data,
+                pagingKey = pagingKey,
+                sortIds = sortIds,
+            )
         return PagingResult(
             data = data,
             nextKey = result.nextKey,

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/datasource/microblog/paging/TimelineUiMapperCache.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/datasource/microblog/paging/TimelineUiMapperCache.kt
@@ -1,0 +1,65 @@
+package dev.dimension.flare.data.datasource.microblog.paging
+
+import dev.dimension.flare.data.database.cache.model.DbPagingTimelineWithStatus
+import dev.dimension.flare.data.database.cache.model.TranslationDisplayOptions
+import dev.dimension.flare.ui.model.UiTimelineV2
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/** Bounded LRU for the expensive database-model to UI-model conversion. */
+internal class TimelineUiMapperCache(
+    private val maxSize: Int = DEFAULT_MAX_SIZE,
+) {
+    private val mutex = Mutex()
+    private val entries = LinkedHashMap<Key, Entry>()
+
+    init {
+        require(maxSize > 0) { "maxSize must be positive" }
+    }
+
+    suspend fun toUi(
+        item: DbPagingTimelineWithStatus,
+        pagingKey: String,
+        translationDisplayOptions: TranslationDisplayOptions,
+    ): UiTimelineV2 =
+        mutex.withLock {
+            val key = Key(pagingKey = pagingKey, timelineId = item.timeline._id)
+            val cached = entries.remove(key)
+            if (cached != null && cached.item === item && cached.translationDisplayOptions == translationDisplayOptions) {
+                entries[key] = cached
+                return@withLock cached.ui
+            }
+
+            val ui =
+                TimelinePagingMapper.toUi(
+                    item = item,
+                    pagingKey = pagingKey,
+                    translationDisplayOptions = translationDisplayOptions,
+                )
+            entries[key] =
+                Entry(
+                    item = item,
+                    translationDisplayOptions = translationDisplayOptions,
+                    ui = ui,
+                )
+            if (entries.size > maxSize) {
+                entries.remove(entries.keys.first())
+            }
+            ui
+        }
+
+    private data class Key(
+        val pagingKey: String,
+        val timelineId: String,
+    )
+
+    private data class Entry(
+        val item: DbPagingTimelineWithStatus,
+        val translationDisplayOptions: TranslationDisplayOptions,
+        val ui: UiTimelineV2,
+    )
+
+    private companion object {
+        const val DEFAULT_MAX_SIZE = 1024
+    }
+}

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/ui/presenter/home/TimelinePresenter.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/ui/presenter/home/TimelinePresenter.kt
@@ -8,13 +8,15 @@ import androidx.paging.ExperimentalPagingApi
 import androidx.paging.Pager
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
-import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.filter
 import androidx.paging.map
 import dev.dimension.flare.common.InAppNotification
 import dev.dimension.flare.common.Message
+import dev.dimension.flare.common.PagingPresentationItem
+import dev.dimension.flare.common.PagingPresentationMapper
 import dev.dimension.flare.common.PagingState
 import dev.dimension.flare.common.PlatformDispatchers
+import dev.dimension.flare.common.collectAsEventAwarePagingItems
 import dev.dimension.flare.common.emptyFlow
 import dev.dimension.flare.common.onEmpty
 import dev.dimension.flare.common.onError
@@ -237,7 +239,7 @@ public open class TimelinePresenter : PresenterBase<TimelineState> {
         val listState =
             remember {
                 createPager(scope)
-            }.collectAsLazyPagingItems()
+            }.collectAsEventAwarePagingItems(TimelinePresentationMapper)
                 .toPagingState()
         return object : TimelineState {
             override val listState = listState
@@ -260,6 +262,21 @@ public open class TimelinePresenter : PresenterBase<TimelineState> {
             }
         }
     }
+}
+
+private object TimelinePresentationMapper : PagingPresentationMapper<UiTimelineV2> {
+    override fun map(item: UiTimelineV2): PagingPresentationItem =
+        PagingPresentationItem(
+            key =
+                item.itemKey
+                    ?.takeIf { it.isNotEmpty() }
+                    ?: listOf(
+                        item.itemType,
+                        item.accountType.toString(),
+                        item.statusKey.toString(),
+                    ).joinToString(":"),
+            renderHash = item.renderHash,
+        )
 }
 
 internal suspend fun shouldRefreshTimelineOnInitialize(

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/ui/presenter/home/TimelinePresenter.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/ui/presenter/home/TimelinePresenter.kt
@@ -30,8 +30,8 @@ import dev.dimension.flare.data.datasource.microblog.paging.OffsetFromStartPagin
 import dev.dimension.flare.data.datasource.microblog.paging.RemoteLoader
 import dev.dimension.flare.data.datasource.microblog.paging.TimelineDbPageCache
 import dev.dimension.flare.data.datasource.microblog.paging.TimelineDbPageLoader
-import dev.dimension.flare.data.datasource.microblog.paging.TimelinePagingMapper
 import dev.dimension.flare.data.datasource.microblog.paging.TimelineRemoteMediator
+import dev.dimension.flare.data.datasource.microblog.paging.TimelineUiMapperCache
 import dev.dimension.flare.data.datasource.microblog.paging.notSupported
 import dev.dimension.flare.data.datasource.microblog.paging.toPagingSource
 import dev.dimension.flare.data.datasource.microblog.pagingConfig
@@ -141,6 +141,7 @@ public open class TimelinePresenter : PresenterBase<TimelineState> {
                     }
 
                     is CacheableRemoteLoader<UiTimelineV2> -> {
+                        val uiMapperCache = TimelineUiMapperCache()
                         cachePager(
                             loader = remoteLoader,
                         ).cachedIn(scope).flatMapLatest { pagingData ->
@@ -148,7 +149,7 @@ public open class TimelinePresenter : PresenterBase<TimelineState> {
                                 .map { translationDisplayOptions ->
                                     withContext(PlatformDispatchers.IO) {
                                         pagingData.map { item ->
-                                            TimelinePagingMapper.toUi(
+                                            uiMapperCache.toUi(
                                                 item = item,
                                                 pagingKey = remoteLoader.pagingKey,
                                                 translationDisplayOptions = translationDisplayOptions,

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/ui/render/UiRichText.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/ui/render/UiRichText.kt
@@ -117,9 +117,8 @@ public data class UiRichText(
         }
     public val isLongText: Boolean = innerText.codePointCount() > 500
     public val truncatedText: String? = if (isLongText) innerText.take(500) + "…" else null
-    public val platformText: PlatformText by lazy {
-        renderPlatformText(renderRuns)
-    }
+    public val platformText: PlatformText
+        get() = renderPlatformText(renderRuns)
 }
 
 @HiddenFromObjC

--- a/shared/src/commonTest/kotlin/dev/dimension/flare/benchmark/BenchmarkRuntime.kt
+++ b/shared/src/commonTest/kotlin/dev/dimension/flare/benchmark/BenchmarkRuntime.kt
@@ -1,0 +1,6 @@
+package dev.dimension.flare.benchmark
+
+internal expect val benchmarkPlatform: String
+
+/** Returns the best available post-GC live heap estimate for the current platform. */
+internal expect fun collectLiveHeapBytes(): Long?

--- a/shared/src/commonTest/kotlin/dev/dimension/flare/common/PagingPresentationTrackerTest.kt
+++ b/shared/src/commonTest/kotlin/dev/dimension/flare/common/PagingPresentationTrackerTest.kt
@@ -1,0 +1,187 @@
+package dev.dimension.flare.common
+
+import androidx.paging.ItemSnapshotList
+import kotlinx.collections.immutable.persistentListOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class PagingPresentationTrackerTest {
+    @Test
+    fun unchangedRefreshKeepsRevisionAndSnapshot() {
+        val items = persistentListOf(item("a"), item("b"))
+        val tracker = PagingPresentationTracker(initialItems = items)
+        val initial = tracker.snapshot
+
+        val refreshed = tracker.refresh(items)
+
+        assertSame(initial, refreshed)
+        assertEquals(0L, refreshed.revision)
+        assertNull(refreshed.change)
+    }
+
+    @Test
+    fun contentRefreshOnlyReloadsChangedIdentity() {
+        val tracker =
+            PagingPresentationTracker(
+                initialItems = persistentListOf(item("a"), item("b"), item("c")),
+            )
+
+        val refreshed =
+            tracker.refresh(
+                persistentListOf(item("a"), item("b", renderHash = 2), item("c")),
+            )
+
+        val change = requireNotNull(refreshed.change)
+        assertEquals(0L, change.baseRevision)
+        assertEquals(1L, change.revision)
+        assertNull(change.replacement)
+        assertEquals(1, change.reloadedCount)
+        assertEquals("b", change.reloadedItemAt(0)?.key)
+        assertEquals(2, change.reloadedItemAt(0)?.renderHash)
+    }
+
+    @Test
+    fun topInsertionKeepsStableSuffixOutsideReplacement() {
+        val tracker =
+            PagingPresentationTracker(
+                initialItems = persistentListOf(item("a"), item("b"), item("c")),
+            )
+
+        val refreshed =
+            tracker.refresh(
+                persistentListOf(item("new"), item("a"), item("b"), item("c", renderHash = 2)),
+            )
+
+        val change = requireNotNull(refreshed.change)
+        val replacement = requireNotNull(change.replacement)
+        assertEquals(0, replacement.startIndex)
+        assertEquals(0, replacement.removeCount)
+        assertEquals(1, replacement.insertedCount)
+        assertEquals("new", replacement.insertedItemAt(0)?.key)
+        assertEquals(listOf("c"), reloadedKeys(change))
+    }
+
+    @Test
+    fun appendFastPathOnlyPublishesInsertedPage() {
+        val tracker =
+            PagingPresentationTracker(
+                initialItems = persistentListOf(item("a"), item("b")),
+            )
+        val mapper = PagingPresentationMapper<String> { item(it) }
+
+        val appended =
+            tracker.appendOrRefresh(
+                startIndex = 2,
+                inserted = listOf(item("c"), item("d")),
+                newItems = ItemSnapshotList(0, 0, listOf("a", "b", "c", "d")),
+                mapper = mapper,
+                hasPlaceholders = false,
+            )
+
+        val replacement = requireNotNull(appended.change?.replacement)
+        assertEquals(2, replacement.startIndex)
+        assertEquals(0, replacement.removeCount)
+        assertEquals(listOf("c", "d"), insertedKeys(replacement))
+    }
+
+    @Test
+    fun prependFastPathOnlyPublishesInsertedPage() {
+        val tracker =
+            PagingPresentationTracker(
+                initialItems = persistentListOf(item("c"), item("d")),
+            )
+        val mapper = PagingPresentationMapper<String> { item(it) }
+
+        val prepended =
+            tracker.prependOrRefresh(
+                inserted = listOf(item("a"), item("b")),
+                newItems = ItemSnapshotList(0, 0, listOf("a", "b", "c", "d")),
+                mapper = mapper,
+                hasPlaceholders = false,
+            )
+
+        val replacement = requireNotNull(prepended.change?.replacement)
+        assertEquals(0, replacement.startIndex)
+        assertEquals(0, replacement.removeCount)
+        assertEquals(listOf("a", "b"), insertedKeys(replacement))
+    }
+
+    @Test
+    fun dropFastPathPublishesRemovedRange() {
+        val tracker =
+            PagingPresentationTracker(
+                initialItems = persistentListOf(item("a"), item("b"), item("c"), item("d")),
+            )
+        val mapper = PagingPresentationMapper<String> { item(it) }
+
+        val dropped =
+            tracker.removeOrRefresh(
+                startIndex = 2,
+                removeCount = 2,
+                newItems = ItemSnapshotList(0, 0, listOf("a", "b")),
+                mapper = mapper,
+                hasPlaceholders = false,
+            )
+
+        val replacement = requireNotNull(dropped.change?.replacement)
+        assertEquals(2, replacement.startIndex)
+        assertEquals(2, replacement.removeCount)
+        assertEquals(0, replacement.insertedCount)
+    }
+
+    @Test
+    fun consecutiveChangesFormRevisionChain() {
+        val tracker = PagingPresentationTracker(initialItems = persistentListOf(item("a")))
+        val mapper = PagingPresentationMapper<String> { item(it) }
+
+        val appended =
+            tracker.appendOrRefresh(
+                startIndex = 1,
+                inserted = listOf(item("b")),
+                newItems = ItemSnapshotList(0, 0, listOf("a", "b")),
+                mapper = mapper,
+                hasPlaceholders = false,
+            )
+        val refreshed = tracker.refresh(persistentListOf(item("a", renderHash = 2), item("b")))
+
+        assertEquals(0L, appended.change?.baseRevision)
+        assertEquals(1L, appended.revision)
+        assertEquals(1L, refreshed.change?.baseRevision)
+        assertEquals(2L, refreshed.revision)
+        assertEquals(listOf("a"), reloadedKeys(requireNotNull(refreshed.change)))
+    }
+
+    @Test
+    fun invalidAppendHintFallsBackToSnapshotDiff() {
+        val tracker =
+            PagingPresentationTracker(
+                initialItems = persistentListOf(item("a"), item("b")),
+            )
+        val mapper = PagingPresentationMapper<String> { item(it) }
+
+        val refreshed =
+            tracker.appendOrRefresh(
+                startIndex = 99,
+                inserted = listOf(item("c")),
+                newItems = ItemSnapshotList(0, 0, listOf("a", "b", "c")),
+                mapper = mapper,
+                hasPlaceholders = false,
+            )
+
+        val replacement = requireNotNull(refreshed.change?.replacement)
+        assertEquals(2, replacement.startIndex)
+        assertEquals(listOf("c"), insertedKeys(replacement))
+    }
+}
+
+private fun item(
+    key: String,
+    renderHash: Int = 1,
+): PagingPresentationItem = PagingPresentationItem(key = key, renderHash = renderHash)
+
+private fun insertedKeys(replacement: PagingPresentationReplacement): List<String?> =
+    List(replacement.insertedCount) { replacement.insertedItemAt(it)?.key }
+
+private fun reloadedKeys(change: PagingPresentationChange): List<String?> = List(change.reloadedCount) { change.reloadedItemAt(it)?.key }

--- a/shared/src/commonTest/kotlin/dev/dimension/flare/data/database/cache/TimelineDatabaseBenchmarkTest.kt
+++ b/shared/src/commonTest/kotlin/dev/dimension/flare/data/database/cache/TimelineDatabaseBenchmarkTest.kt
@@ -1,0 +1,797 @@
+package dev.dimension.flare.data.database.cache
+
+import androidx.paging.PagingSource
+import androidx.room3.Room
+import dev.dimension.flare.RobolectricTest
+import dev.dimension.flare.benchmark.benchmarkPlatform
+import dev.dimension.flare.benchmark.collectLiveHeapBytes
+import dev.dimension.flare.common.Locale
+import dev.dimension.flare.common.PlatformDispatchers
+import dev.dimension.flare.data.database.cache.mapper.saveToDatabase
+import dev.dimension.flare.data.database.cache.model.DbPagingTimelineWithStatus
+import dev.dimension.flare.data.database.cache.model.DbStatus
+import dev.dimension.flare.data.database.cache.model.DbTranslation
+import dev.dimension.flare.data.database.cache.model.TranslationDisplayOptions
+import dev.dimension.flare.data.database.cache.model.TranslationEntityType
+import dev.dimension.flare.data.database.cache.model.TranslationPayload
+import dev.dimension.flare.data.database.cache.model.TranslationStatus
+import dev.dimension.flare.data.database.cache.model.sourceHash
+import dev.dimension.flare.data.database.cache.model.translationPayload
+import dev.dimension.flare.data.database.createDatabaseDriver
+import dev.dimension.flare.data.datasource.microblog.paging.OffsetFromStartPagingKey
+import dev.dimension.flare.data.datasource.microblog.paging.OffsetFromStartPagingSource
+import dev.dimension.flare.data.datasource.microblog.paging.TimelineDbPageCache
+import dev.dimension.flare.data.datasource.microblog.paging.TimelineDbPageLoader
+import dev.dimension.flare.data.datasource.microblog.paging.TimelinePagingMapper
+import dev.dimension.flare.data.datasource.microblog.paging.TimelineUiMapperCache
+import dev.dimension.flare.memoryDatabaseBuilder
+import dev.dimension.flare.model.AccountType
+import dev.dimension.flare.model.MicroBlogKey
+import dev.dimension.flare.model.ReferenceType
+import dev.dimension.flare.ui.model.ClickEvent
+import dev.dimension.flare.ui.model.UiHandle
+import dev.dimension.flare.ui.model.UiProfile
+import dev.dimension.flare.ui.model.UiTimelineV2
+import dev.dimension.flare.ui.model.UiTranslatableText
+import dev.dimension.flare.ui.render.toUi
+import dev.dimension.flare.ui.render.toUiPlainText
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlin.math.roundToLong
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+import kotlin.time.measureTime
+
+/**
+ * Cross-platform baseline for the database path seen in the iOS Instruments trace.
+ *
+ * Run explicitly with:
+ * ./gradlew :shared:<target>Test -PrunDatabaseBenchmark=true --tests '*TimelineDatabaseBenchmarkTest*'
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class TimelineDatabaseBenchmarkTest : RobolectricTest() {
+    /**
+     * Production-shaped benchmark for the complete timeline lifecycle.
+     *
+     * Unlike [benchmarkTimelineDatabase], this includes UI -> database mapping, diffed writes,
+     * Room invalidation delivery, stable-prefix refresh, database -> UI mapping, and render hash
+     * evaluation. The same [TimelineDbPageCache] survives paging-source replacement, matching the
+     * non-Android timeline presenter.
+     */
+    @Test
+    fun benchmarkTimelineLifecycle() =
+        runTest(timeout = 5.minutes) {
+            val database =
+                Room
+                    .memoryDatabaseBuilder<CacheDatabase>()
+                    .setDriver(createDatabaseDriver())
+                    .setQueryCoroutineContext(PlatformDispatchers.IO)
+                    .build()
+
+            try {
+                warmUpDatabase(database)
+                val pageCache = TimelineDbPageCache()
+                val loader =
+                    TimelineDbPageLoader(
+                        database = database,
+                        pagingKey = LIFECYCLE_PAGING_KEY,
+                        pageCache = pageCache,
+                    )
+                val displayOptions =
+                    TranslationDisplayOptions(
+                        translationEnabled = true,
+                        autoDisplayEnabled = true,
+                        providerCacheKey = LIFECYCLE_TRANSLATION_PROVIDER,
+                    )
+                val uiMapperCache = TimelineUiMapperCache(maxSize = LIFECYCLE_ROWS + PAGE_SIZE)
+
+                var checksum = 0L
+                var retainedUi: List<UiTimelineV2> = emptyList()
+
+                val initialElapsed =
+                    measureTime {
+                        val initialUi = createRealisticTimelineItems(startIndex = 0, count = PAGE_SIZE, revision = 0)
+                        val mapped = mapTimelineItems(initialUi, startIndex = 0)
+                        database.connect { saveToDatabase(database, mapped) }
+                        val page = loader.load(offset = 0, limit = PAGE_SIZE)
+                        retainedUi = page.map { uiMapperCache.toUi(it, LIFECYCLE_PAGING_KEY, displayOptions) }
+                        checksum = checksum * 31 + retainedUi.renderChecksum()
+                    }
+
+                val appendSamples = LongArray(LIFECYCLE_ROWS / PAGE_SIZE - 1)
+                appendSamples.indices.forEach { pageIndex ->
+                    val startIndex = (pageIndex + 1) * PAGE_SIZE
+                    val elapsed =
+                        measureTime {
+                            val pageUi = createRealisticTimelineItems(startIndex, PAGE_SIZE, revision = 0)
+                            val mapped = mapTimelineItems(pageUi, startIndex)
+                            database.connect { saveToDatabase(database, mapped) }
+                            val page = loader.load(offset = startIndex, limit = PAGE_SIZE)
+                            val rendered = page.map { uiMapperCache.toUi(it, LIFECYCLE_PAGING_KEY, displayOptions) }
+                            checksum = checksum * 31 + rendered.renderChecksum()
+                        }
+                    appendSamples[pageIndex] = elapsed.inWholeNanoseconds
+                }
+
+                seedLifecycleTranslations(database)
+                retainedUi =
+                    loader
+                        .load(offset = 0, limit = PAGE_SIZE)
+                        .map { uiMapperCache.toUi(it, LIFECYCLE_PAGING_KEY, displayOptions) }
+                assertEquals(LIFECYCLE_ROWS, retainedUi.size)
+                val heapWithStablePrefix = collectLiveHeapBytes()
+
+                var pagingSource = OffsetFromStartPagingSource(loader)
+                retainedUi =
+                    loadLifecycleRefresh(pagingSource).map {
+                        uiMapperCache.toUi(it, LIFECYCLE_PAGING_KEY, displayOptions)
+                    }
+
+                val unchangedUi = createRealisticTimelineItems(startIndex = 0, count = PAGE_SIZE, revision = 0)
+                val unchangedSamples =
+                    measureSamples(warmups = 1, iterations = LIFECYCLE_REFRESH_ITERATIONS) {
+                        val mapped = mapTimelineItems(unchangedUi, startIndex = 0)
+                        database.connect { saveToDatabase(database, mapped) }
+                        mapped.fold(0L) { value, item -> value * 31 + item.statusData.contentHash }
+                    }
+
+                val changedSamples = LongArray(LIFECYCLE_REFRESH_ITERATIONS)
+                repeat(LIFECYCLE_REFRESH_ITERATIONS) { iteration ->
+                    val invalidated = CompletableDeferred<Unit>()
+                    pagingSource.registerInvalidatedCallback { invalidated.complete(Unit) }
+                    val elapsed =
+                        measureTime {
+                            val changedUi =
+                                createRealisticTimelineItems(
+                                    startIndex = 0,
+                                    count = PAGE_SIZE,
+                                    revision = iteration + 1,
+                                )
+                            val mapped = mapTimelineItems(changedUi, startIndex = 0)
+                            database.connect { saveToDatabase(database, mapped) }
+                            awaitLifecycleInvalidation(invalidated)
+
+                            pagingSource = OffsetFromStartPagingSource(loader)
+                            retainedUi =
+                                loadLifecycleRefresh(pagingSource).map {
+                                    uiMapperCache.toUi(it, LIFECYCLE_PAGING_KEY, displayOptions)
+                                }
+                            assertEquals(LIFECYCLE_ROWS, retainedUi.size)
+                            checksum = checksum * 31 + retainedUi.renderChecksum()
+                        }
+                    changedSamples[iteration] = elapsed.inWholeNanoseconds
+                }
+
+                val translationInvalidated = CompletableDeferred<Unit>()
+                pagingSource.registerInvalidatedCallback { translationInvalidated.complete(Unit) }
+                val translationElapsed =
+                    measureTime {
+                        val latestRoot = createRealisticTimelineItems(0, 1, revision = LIFECYCLE_REFRESH_ITERATIONS).single().post
+                        database.translationDao().insert(latestRoot.completedTranslation(updatedAt = FIXED_EPOCH_MILLIS + 50_000))
+                        awaitLifecycleInvalidation(translationInvalidated)
+                        pagingSource = OffsetFromStartPagingSource(loader)
+                        retainedUi =
+                            loadLifecycleRefresh(pagingSource).map {
+                                uiMapperCache.toUi(it, LIFECYCLE_PAGING_KEY, displayOptions)
+                            }
+                        assertEquals(LIFECYCLE_ROWS, retainedUi.size)
+                        checksum = checksum * 31 + retainedUi.renderChecksum()
+                    }
+
+                val insertInvalidated = CompletableDeferred<Unit>()
+                pagingSource.registerInvalidatedCallback { insertInvalidated.complete(Unit) }
+                val topInsertElapsed =
+                    measureTime {
+                        val insertedUi = createRealisticTimelineItems(startIndex = -1, count = 1, revision = 1)
+                        database.connect { saveToDatabase(database, mapTimelineItems(insertedUi, startIndex = -1)) }
+                        awaitLifecycleInvalidation(insertInvalidated)
+                        pagingSource = OffsetFromStartPagingSource(loader)
+                        retainedUi =
+                            loadLifecycleRefresh(pagingSource).map {
+                                uiMapperCache.toUi(it, LIFECYCLE_PAGING_KEY, displayOptions)
+                            }
+                        assertEquals(LIFECYCLE_ROWS + 1, retainedUi.size)
+                        checksum = checksum * 31 + retainedUi.renderChecksum()
+                    }
+                val heapAfterLifecycle = collectLiveHeapBytes()
+
+                println("TIMELINE_LIFECYCLE_BENCHMARK version=$LIFECYCLE_BENCHMARK_VERSION platform=$benchmarkPlatform")
+                println(
+                    "config retained_rows=$LIFECYCLE_ROWS page_size=$PAGE_SIZE users=$LIFECYCLE_USER_COUNT " +
+                        "semantic_references_per_root=$REFERENCES_PER_ROOT " +
+                        "presentation_references_per_root=$REFERENCES_PER_ROOT payload_chars=$LIFECYCLE_PAYLOAD_CHARS " +
+                        "translated_root_stride=$LIFECYCLE_TRANSLATION_STRIDE refresh_iterations=$LIFECYCLE_REFRESH_ITERATIONS",
+                )
+                printMetric("initial_page_full_chain", BenchmarkSamples(longArrayOf(initialElapsed.inWholeNanoseconds), checksum))
+                printMetric("append_page_full_chain", BenchmarkSamples(appendSamples, checksum))
+                printMetric("unchanged_network_refresh", unchangedSamples)
+                printMetric("changed_refresh_full_chain", BenchmarkSamples(changedSamples, checksum), "retained_rows=$LIFECYCLE_ROWS")
+                printMetric(
+                    "translation_refresh_full_chain",
+                    BenchmarkSamples(longArrayOf(translationElapsed.inWholeNanoseconds), checksum),
+                    "retained_rows=$LIFECYCLE_ROWS",
+                )
+                printMetric(
+                    "top_insert_full_chain",
+                    BenchmarkSamples(longArrayOf(topInsertElapsed.inWholeNanoseconds), checksum),
+                    "retained_rows=${LIFECYCLE_ROWS + 1}",
+                )
+                printHeap("lifecycle_stable_prefix", heapWithStablePrefix)
+                printHeap("lifecycle_complete", heapAfterLifecycle)
+                println("lifecycle_checksum=${checksum + retainedUi.size}")
+
+                pagingSource.invalidate()
+                // Let the paging source's invalidation observer finish cancellation before Room closes.
+                withContext(PlatformDispatchers.IO) { delay(50) }
+            } finally {
+                database.close()
+            }
+        }
+
+    @Test
+    fun benchmarkTimelineDatabase() =
+        runTest(timeout = 5.minutes) {
+            val database =
+                Room
+                    .memoryDatabaseBuilder<CacheDatabase>()
+                    .setDriver(createDatabaseDriver())
+                    .setQueryCoroutineContext(Dispatchers.Unconfined)
+                    .build()
+
+            try {
+                warmUpDatabase(database)
+                val heapBeforeSeed = collectLiveHeapBytes()
+                val seed = seedDatabase(database)
+                seedTranslations(database, seed.statusIds)
+                val heapAfterSeed = collectLiveHeapBytes()
+
+                val pageMetrics = benchmarkPageReads(database)
+                val pageWindowMetrics = benchmarkPageWindowReads(database)
+                val identityMetrics = benchmarkIdentityReads(database)
+                val heapAfterReads = collectLiveHeapBytes()
+                val stablePrefix = benchmarkStablePrefixRefresh(database)
+                val heapWithStablePrefix = collectLiveHeapBytes()
+
+                println("TIMELINE_DB_BENCHMARK version=$BENCHMARK_VERSION platform=$benchmarkPlatform")
+                println(
+                    "config root_rows=$ROOT_ROWS incoming_status_instances=${seed.statusInstanceCount} " +
+                        "unique_status_rows=${seed.statusIds.size} semantic_references_per_root=$REFERENCES_PER_ROOT " +
+                        "presentation_references_per_root=$REFERENCES_PER_ROOT payload_chars=$PAYLOAD_CHARS " +
+                        "page_size=$PAGE_SIZE warmups=$WARMUP_ITERATIONS iterations=$MEASURE_ITERATIONS",
+                )
+                printMetric("initial_write", seed.initialWrite)
+                printMetric("unchanged_rewrite", seed.unchangedRewrite)
+                printMetric("equivalent_remap_rewrite", seed.equivalentRemapRewrite)
+                pageMetrics.forEach { (offset, samples) ->
+                    printMetric("page_read", samples, "offset=$offset limit=$PAGE_SIZE")
+                }
+                pageWindowMetrics.forEach { (limit, samples) ->
+                    printMetric("page_window_read", samples, "offset=0 limit=$limit")
+                }
+                identityMetrics.forEach { (limit, samples) ->
+                    printMetric("identity_read", samples, "offset=0 limit=$limit")
+                }
+                printMetric(
+                    "stable_prefix_refresh",
+                    stablePrefix.samples,
+                    "requested_limit=$PAGE_SIZE retained_rows=${stablePrefix.retainedRows.size}",
+                )
+                printHeap("before_seed", heapBeforeSeed)
+                printHeap("after_seed", heapAfterSeed)
+                printHeap("after_reads", heapAfterReads)
+                printHeap("with_stable_prefix", heapWithStablePrefix)
+                println(
+                    "checksum=${
+                        seed.checksum +
+                            pageMetrics.values.sumOf { it.checksum } +
+                            pageWindowMetrics.values.sumOf { it.checksum } +
+                            identityMetrics.values.sumOf { it.checksum } +
+                            stablePrefix.samples.checksum +
+                            stablePrefix.retainedRows.size
+                    }",
+                )
+            } finally {
+                database.close()
+            }
+        }
+
+    private suspend fun warmUpDatabase(database: CacheDatabase) {
+        val items = createTimelineItems(WARMUP_PAGING_KEY, startIndex = ROOT_ROWS, count = PAGE_SIZE)
+        database.connect {
+            saveToDatabase(database, items)
+        }
+        database.loadTimelinePage(WARMUP_PAGING_KEY, offset = 0, limit = PAGE_SIZE)
+        database.loadTimelinePageIdentities(WARMUP_PAGING_KEY, offset = 0, limit = PAGE_SIZE)
+    }
+
+    private suspend fun seedDatabase(database: CacheDatabase): SeedResult {
+        val items = createTimelineItems(BENCHMARK_PAGING_KEY, startIndex = 0, count = ROOT_ROWS)
+        val statusIds = collectStatusIds(items)
+        val statusInstanceCount = countStatusInstances(items)
+        assertEquals(ROOT_ROWS * (REFERENCES_PER_ROOT + 1), statusIds.size)
+
+        val initialWrite =
+            measureSingle {
+                database.connect {
+                    saveToDatabase(database, items)
+                }
+            }
+        assertEquals(
+            ROOT_ROWS,
+            database.loadTimelinePageIdentities(BENCHMARK_PAGING_KEY, offset = 0, limit = ROOT_ROWS + 1).size,
+        )
+
+        val unchangedRewrite =
+            measureSamples(warmups = 1, iterations = REWRITE_ITERATIONS) {
+                database.connect {
+                    saveToDatabase(database, items)
+                }
+                statusIds.size.toLong()
+            }
+
+        val equivalentRemapRewrite =
+            measureSamples(warmups = 1, iterations = REWRITE_ITERATIONS) {
+                val remappedItems =
+                    createTimelineItems(
+                        pagingKey = BENCHMARK_PAGING_KEY,
+                        startIndex = 0,
+                        count = ROOT_ROWS,
+                    )
+                database.connect {
+                    saveToDatabase(database, remappedItems)
+                }
+                countStatusInstances(remappedItems).toLong()
+            }
+
+        return SeedResult(
+            statusIds = statusIds,
+            statusInstanceCount = statusInstanceCount,
+            initialWrite = initialWrite,
+            unchangedRewrite = unchangedRewrite,
+            equivalentRemapRewrite = equivalentRemapRewrite,
+            checksum = statusIds.fold(0L) { checksum, id -> checksum * 31 + id.length },
+        )
+    }
+
+    private suspend fun seedTranslations(
+        database: CacheDatabase,
+        statusIds: List<String>,
+    ) {
+        val translations =
+            statusIds.mapIndexed { index, statusId ->
+                DbTranslation(
+                    entityType = TranslationEntityType.Status,
+                    entityKey = statusId,
+                    targetLanguage = "zh-CN",
+                    sourceHash = "benchmark-$index",
+                    status = TranslationStatus.Completed,
+                    updatedAt = FIXED_EPOCH_MILLIS + index,
+                )
+            }
+        database.connect {
+            database.translationDao().insertAll(translations)
+        }
+    }
+
+    private suspend fun benchmarkPageReads(database: CacheDatabase): Map<Int, BenchmarkSamples> =
+        PAGE_OFFSETS.associateWith { offset ->
+            val initial = database.loadTimelinePage(BENCHMARK_PAGING_KEY, offset, PAGE_SIZE)
+            assertEquals(PAGE_SIZE, initial.size)
+            assertEquals(PAGE_SIZE * REFERENCES_PER_ROOT, initial.sumOf { it.references.size })
+            assertEquals(PAGE_SIZE * REFERENCES_PER_ROOT, initial.sumOf { it.presentationReferences.size })
+
+            measureSamples {
+                val page = database.loadTimelinePage(BENCHMARK_PAGING_KEY, offset, PAGE_SIZE)
+                page.fold(page.size.toLong()) { checksum, item ->
+                    checksum * 31 +
+                        item.timeline.sortId +
+                        item.statusTranslations.size +
+                        item.references.size +
+                        item.presentationReferences.size
+                }
+            }
+        }
+
+    private suspend fun benchmarkIdentityReads(database: CacheDatabase): Map<Int, BenchmarkSamples> =
+        IDENTITY_LIMITS.associateWith { limit ->
+            val initial = database.loadTimelinePageIdentities(BENCHMARK_PAGING_KEY, offset = 0, limit = limit)
+            assertEquals(limit, initial.size)
+
+            measureSamples {
+                database
+                    .loadTimelinePageIdentities(BENCHMARK_PAGING_KEY, offset = 0, limit = limit)
+                    .fold(0L) { checksum, identity ->
+                        checksum * 31 +
+                            identity.sortId +
+                            identity.rootContentHash +
+                            identity.dependencyRevision +
+                            identity.dependencyCount
+                    }
+            }
+        }
+
+    private suspend fun benchmarkPageWindowReads(database: CacheDatabase): Map<Int, BenchmarkSamples> =
+        PAGE_WINDOW_LIMITS.associateWith { limit ->
+            val initial = database.loadTimelinePage(BENCHMARK_PAGING_KEY, offset = 0, limit = limit)
+            assertEquals(limit, initial.size)
+
+            measureSamples(warmups = 1, iterations = WINDOW_MEASURE_ITERATIONS) {
+                database
+                    .loadTimelinePage(BENCHMARK_PAGING_KEY, offset = 0, limit = limit)
+                    .fold(0L) { checksum, item ->
+                        checksum * 31 +
+                            item.timeline.sortId +
+                            item.statusTranslations.size +
+                            item.references.size +
+                            item.presentationReferences.size
+                    }
+            }
+        }
+
+    private suspend fun benchmarkStablePrefixRefresh(database: CacheDatabase): StablePrefixBenchmarkResult {
+        val loader =
+            TimelineDbPageLoader(
+                database = database,
+                pagingKey = BENCHMARK_PAGING_KEY,
+                pageCache = TimelineDbPageCache(),
+            )
+        val initial = loader.load(offset = 0, limit = ROOT_ROWS)
+        assertEquals(ROOT_ROWS, initial.size)
+
+        lateinit var retainedRows: List<DbPagingTimelineWithStatus>
+        val samples =
+            measureSamples(warmups = 1, iterations = WINDOW_MEASURE_ITERATIONS) {
+                retainedRows = loader.load(offset = 0, limit = PAGE_SIZE)
+                retainedRows
+                    .fold(0L) { checksum, item ->
+                        checksum * 31 + item.timeline.sortId + item.status.references.size
+                    }
+            }
+        return StablePrefixBenchmarkResult(samples = samples, retainedRows = retainedRows)
+    }
+
+    private suspend fun createTimelineItems(
+        pagingKey: String,
+        startIndex: Int,
+        count: Int,
+    ): List<DbPagingTimelineWithStatus> {
+        val result = ArrayList<DbPagingTimelineWithStatus>(count)
+        repeat(count) { relativeIndex ->
+            val index = startIndex + relativeIndex
+            val parent = createPost(index, "parent")
+            val quote = createPost(index, "quote")
+            val repost = createPost(index, "repost")
+            val root =
+                createPost(
+                    index = index,
+                    role = "root",
+                    references =
+                        persistentListOf(
+                            UiTimelineV2.Post.Reference(parent.statusKey, ReferenceType.Reply),
+                            UiTimelineV2.Post.Reference(quote.statusKey, ReferenceType.Quote),
+                            UiTimelineV2.Post.Reference(repost.statusKey, ReferenceType.Retweet),
+                        ),
+                )
+            result +=
+                TimelinePagingMapper.toDb(
+                    data =
+                        UiTimelineV2.TimelinePostItem(
+                            post = root,
+                            presentation =
+                                UiTimelineV2.PostPresentation(
+                                    inlineParents = persistentListOf(parent),
+                                    quotes = persistentListOf(quote),
+                                    repost = repost,
+                                ),
+                        ),
+                    pagingKey = pagingKey,
+                    sortId = index.toLong(),
+                )
+        }
+        return result
+    }
+
+    private suspend fun mapTimelineItems(
+        items: List<UiTimelineV2.TimelinePostItem>,
+        startIndex: Int,
+    ): List<DbPagingTimelineWithStatus> =
+        TimelinePagingMapper.toDb(
+            data = items,
+            pagingKey = LIFECYCLE_PAGING_KEY,
+            sortIds = List(items.size) { index -> (startIndex + index).toLong() },
+        )
+
+    private fun createRealisticTimelineItems(
+        startIndex: Int,
+        count: Int,
+        revision: Int,
+    ): List<UiTimelineV2.TimelinePostItem> =
+        List(count) { relativeIndex ->
+            val index = startIndex + relativeIndex
+            val parent = createRealisticPost(index, "parent", revision, userOffset = 1)
+            val quote = createRealisticPost(index, "quote", revision, userOffset = 2)
+            val repost = createRealisticPost(index, "repost", revision, userOffset = 3)
+            val root =
+                createRealisticPost(
+                    index = index,
+                    role = "root",
+                    revision = revision,
+                    userOffset = 0,
+                    references =
+                        persistentListOf(
+                            UiTimelineV2.Post.Reference(parent.statusKey, ReferenceType.Reply),
+                            UiTimelineV2.Post.Reference(quote.statusKey, ReferenceType.Quote),
+                            UiTimelineV2.Post.Reference(repost.statusKey, ReferenceType.Retweet),
+                        ),
+                )
+            UiTimelineV2.TimelinePostItem(
+                post = root,
+                presentation =
+                    UiTimelineV2.PostPresentation(
+                        inlineParents = persistentListOf(parent),
+                        quotes = persistentListOf(quote),
+                        repost = repost,
+                    ),
+            )
+        }
+
+    private fun createRealisticPost(
+        index: Int,
+        role: String,
+        revision: Int,
+        userOffset: Int,
+        references: kotlinx.collections.immutable.ImmutableList<UiTimelineV2.Post.Reference> = persistentListOf(),
+    ): UiTimelineV2.Post {
+        val userIndex = ((index * 7 + userOffset).mod(LIFECYCLE_USER_COUNT))
+        val user = createBenchmarkUser(userIndex)
+        return UiTimelineV2.Post(
+            platformId = "Mastodon",
+            images = persistentListOf(),
+            sensitive = index.mod(17) == 0,
+            contentWarning =
+                if (index.mod(17) == 0) {
+                    UiTranslatableText("benchmark warning $index".toUiPlainText())
+                } else {
+                    null
+                },
+            user = user,
+            content =
+                UiTranslatableText(
+                    "$role-$index revision=$revision $LIFECYCLE_PAYLOAD_TEXT".toUiPlainText(),
+                ),
+            actions = persistentListOf(),
+            poll = null,
+            statusKey = MicroBlogKey(id = "$role-$index", host = BENCHMARK_HOST),
+            card = null,
+            createdAt = Instant.fromEpochMilliseconds(FIXED_EPOCH_MILLIS + index).toUi(),
+            sourceLanguages = persistentListOf("en"),
+            references = references,
+            clickEvent = ClickEvent.Noop,
+            accountType = AccountType.Guest,
+        )
+    }
+
+    private fun createBenchmarkUser(index: Int): UiProfile {
+        val key = MicroBlogKey(id = "benchmark-user-$index", host = BENCHMARK_HOST)
+        return UiProfile(
+            key = key,
+            handle = UiHandle(raw = key.id, host = key.host),
+            avatar = "https://${key.host}/avatars/${key.id}.png",
+            nameInternal = "Benchmark User $index".toUiPlainText(),
+            platformId = "Mastodon",
+            clickEvent = ClickEvent.Noop,
+            banner = null,
+            description = "Shared benchmark profile $index".toUiPlainText(),
+            matrices =
+                UiProfile.Matrices(
+                    fansCount = index.toLong() * 101,
+                    followsCount = index.toLong() * 7,
+                    statusesCount = index.toLong() * 503,
+                    platformFansCount = (index * 101).toString(),
+                ),
+            mark = persistentListOf(),
+            bottomContent = null,
+        )
+    }
+
+    private suspend fun seedLifecycleTranslations(database: CacheDatabase) {
+        val translations =
+            (0 until LIFECYCLE_ROWS step LIFECYCLE_TRANSLATION_STRIDE).map { index ->
+                createRealisticTimelineItems(index, 1, revision = 0).single().post.completedTranslation(
+                    updatedAt = FIXED_EPOCH_MILLIS + 10_000 + index,
+                )
+            }
+        database.connect { database.translationDao().insertAll(translations) }
+    }
+
+    private fun UiTimelineV2.Post.completedTranslation(updatedAt: Long): DbTranslation {
+        val originalPayload = checkNotNull(translationPayload())
+        return DbTranslation(
+            entityType = TranslationEntityType.Status,
+            entityKey = DbStatus.createId(accountType as dev.dimension.flare.model.DbAccountType, statusKey),
+            targetLanguage = Locale.language,
+            sourceHash = originalPayload.sourceHash(LIFECYCLE_TRANSLATION_PROVIDER),
+            status = TranslationStatus.Completed,
+            payload = TranslationPayload(content = "translated ${content.original.raw.take(80)}".toUiPlainText()),
+            updatedAt = updatedAt,
+        )
+    }
+
+    private suspend fun loadLifecycleRefresh(
+        source: OffsetFromStartPagingSource<DbPagingTimelineWithStatus>,
+    ): List<DbPagingTimelineWithStatus> {
+        val result =
+            source.load(
+                PagingSource.LoadParams.Refresh<OffsetFromStartPagingKey>(
+                    key = null,
+                    loadSize = PAGE_SIZE,
+                    placeholdersEnabled = false,
+                ),
+            )
+        return assertIs<PagingSource.LoadResult.Page<OffsetFromStartPagingKey, DbPagingTimelineWithStatus>>(result).data
+    }
+
+    private suspend fun awaitLifecycleInvalidation(invalidated: CompletableDeferred<Unit>) {
+        // runTest uses virtual time; invalidation delivery runs on the production IO dispatcher.
+        withContext(PlatformDispatchers.IO) {
+            withTimeout(LIFECYCLE_INVALIDATION_TIMEOUT_MILLIS) { invalidated.await() }
+        }
+    }
+
+    private fun List<UiTimelineV2>.renderChecksum(): Long = fold(size.toLong()) { checksum, item -> checksum * 31 + item.renderHash }
+
+    private fun createPost(
+        index: Int,
+        role: String,
+        references: kotlinx.collections.immutable.ImmutableList<UiTimelineV2.Post.Reference> = persistentListOf(),
+    ): UiTimelineV2.Post {
+        val statusKey = MicroBlogKey(id = "$role-$index", host = BENCHMARK_HOST)
+        return UiTimelineV2.Post(
+            platformId = "Benchmark",
+            images = persistentListOf(),
+            sensitive = false,
+            contentWarning = null,
+            user = null,
+            content = UiTranslatableText("$role-$index $PAYLOAD_TEXT".toUiPlainText()),
+            actions = persistentListOf(),
+            poll = null,
+            statusKey = statusKey,
+            card = null,
+            createdAt = Instant.fromEpochMilliseconds(FIXED_EPOCH_MILLIS + index).toUi(),
+            references = references,
+            clickEvent = ClickEvent.Noop,
+            accountType = AccountType.Guest,
+        )
+    }
+
+    private fun collectStatusIds(items: List<DbPagingTimelineWithStatus>): List<String> =
+        buildList {
+            items.forEach { item ->
+                add(item.status.status.data.id)
+                item.status.references.mapNotNullTo(this) { it.status?.data?.id }
+                item.presentationReferences.mapNotNullTo(this) { it.status?.data?.id }
+            }
+        }.distinct()
+
+    private fun countStatusInstances(items: List<DbPagingTimelineWithStatus>): Int =
+        items.sumOf { item ->
+            1 +
+                item.status.references.count { it.status != null } +
+                item.presentationReferences.count { it.status != null }
+        }
+
+    private suspend fun measureSingle(block: suspend () -> Unit): BenchmarkSamples {
+        val elapsed = measureTime { block() }
+        return BenchmarkSamples(longArrayOf(elapsed.inWholeNanoseconds), checksum = 1L)
+    }
+
+    private suspend fun measureSamples(
+        warmups: Int = WARMUP_ITERATIONS,
+        iterations: Int = MEASURE_ITERATIONS,
+        block: suspend () -> Long,
+    ): BenchmarkSamples {
+        var checksum = 0L
+        repeat(warmups) {
+            checksum = checksum * 31 + block()
+        }
+        val samples = LongArray(iterations)
+        repeat(iterations) { index ->
+            var value = 0L
+            val elapsed = measureTime { value = block() }
+            samples[index] = elapsed.inWholeNanoseconds
+            checksum = checksum * 31 + value
+        }
+        return BenchmarkSamples(samples, checksum)
+    }
+
+    private fun printMetric(
+        name: String,
+        samples: BenchmarkSamples,
+        dimensions: String = "",
+    ) {
+        val prefix = if (dimensions.isEmpty()) "" else "$dimensions "
+        println(
+            "metric name=$name ${prefix}samples=${samples.size} " +
+                "median_ms=${samples.medianMillis.rounded()} " +
+                "p95_ms=${samples.p95Millis.rounded()} " +
+                "min_ms=${samples.minMillis.rounded()}",
+        )
+    }
+
+    private fun printHeap(
+        phase: String,
+        bytes: Long?,
+    ) {
+        println("memory name=live_heap_after_gc phase=$phase bytes=${bytes ?: "unavailable"}")
+    }
+
+    private fun Double.rounded(): Double = (this * 1_000.0).roundToLong() / 1_000.0
+
+    private data class SeedResult(
+        val statusIds: List<String>,
+        val statusInstanceCount: Int,
+        val initialWrite: BenchmarkSamples,
+        val unchangedRewrite: BenchmarkSamples,
+        val equivalentRemapRewrite: BenchmarkSamples,
+        val checksum: Long,
+    )
+
+    private data class BenchmarkSamples(
+        private val nanos: LongArray,
+        val checksum: Long,
+    ) {
+        private val sorted: LongArray = nanos.sortedArray()
+
+        val size: Int = nanos.size
+        val medianMillis: Double = sorted[sorted.size / 2].toMillis()
+        val p95Millis: Double = sorted[((sorted.size * 95 + 99) / 100 - 1).coerceIn(0, sorted.lastIndex)].toMillis()
+        val minMillis: Double = sorted.first().toMillis()
+
+        private fun Long.toMillis(): Double = toDouble() / 1_000_000.0
+    }
+
+    private data class StablePrefixBenchmarkResult(
+        val samples: BenchmarkSamples,
+        val retainedRows: List<DbPagingTimelineWithStatus>,
+    )
+
+    private companion object {
+        const val BENCHMARK_VERSION = 2
+        const val LIFECYCLE_BENCHMARK_VERSION = 2
+        const val BENCHMARK_PAGING_KEY = "timeline-database-benchmark"
+        const val WARMUP_PAGING_KEY = "timeline-database-benchmark-warmup"
+        const val LIFECYCLE_PAGING_KEY = "timeline-lifecycle-benchmark"
+        const val LIFECYCLE_TRANSLATION_PROVIDER = "benchmark-provider-v1"
+        const val BENCHMARK_HOST = "benchmark.invalid"
+        const val ROOT_ROWS = 500
+        const val LIFECYCLE_ROWS = 240
+        const val LIFECYCLE_USER_COUNT = 48
+        const val LIFECYCLE_PAYLOAD_CHARS = 768
+        const val LIFECYCLE_TRANSLATION_STRIDE = 4
+        const val LIFECYCLE_REFRESH_ITERATIONS = 3
+        const val LIFECYCLE_INVALIDATION_TIMEOUT_MILLIS = 10_000L
+        const val PAGE_SIZE = 20
+        const val REFERENCES_PER_ROOT = 3
+        const val PAYLOAD_CHARS = 2_048
+        const val FIXED_EPOCH_MILLIS = 1_700_000_000_000L
+        const val WARMUP_ITERATIONS = 2
+        const val MEASURE_ITERATIONS = 7
+        const val REWRITE_ITERATIONS = 3
+        const val WINDOW_MEASURE_ITERATIONS = 3
+
+        val PAGE_OFFSETS = listOf(0, 240, 480)
+        val PAGE_WINDOW_LIMITS = listOf(20, 100, 500)
+        val IDENTITY_LIMITS = listOf(20, 100, 500)
+        val PAYLOAD_TEXT = "0123456789abcdef".repeat(PAYLOAD_CHARS / 16)
+        val LIFECYCLE_PAYLOAD_TEXT = "timeline payload 0123456789abcdef ".repeat(LIFECYCLE_PAYLOAD_CHARS / 34)
+    }
+}

--- a/shared/src/commonTest/kotlin/dev/dimension/flare/data/database/cache/TimelineDatabaseBenchmarkTest.kt
+++ b/shared/src/commonTest/kotlin/dev/dimension/flare/data/database/cache/TimelineDatabaseBenchmarkTest.kt
@@ -1,11 +1,15 @@
 package dev.dimension.flare.data.database.cache
 
+import androidx.paging.ItemSnapshotList
 import androidx.paging.PagingSource
 import androidx.room3.Room
 import dev.dimension.flare.RobolectricTest
 import dev.dimension.flare.benchmark.benchmarkPlatform
 import dev.dimension.flare.benchmark.collectLiveHeapBytes
 import dev.dimension.flare.common.Locale
+import dev.dimension.flare.common.PagingPresentationItem
+import dev.dimension.flare.common.PagingPresentationMapper
+import dev.dimension.flare.common.PagingPresentationTracker
 import dev.dimension.flare.common.PlatformDispatchers
 import dev.dimension.flare.data.database.cache.mapper.saveToDatabase
 import dev.dimension.flare.data.database.cache.model.DbPagingTimelineWithStatus
@@ -36,6 +40,7 @@ import dev.dimension.flare.ui.model.UiTranslatableText
 import dev.dimension.flare.ui.render.toUi
 import dev.dimension.flare.ui.render.toUiPlainText
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -203,6 +208,7 @@ class TimelineDatabaseBenchmarkTest : RobolectricTest() {
                         checksum = checksum * 31 + retainedUi.renderChecksum()
                     }
                 val heapAfterLifecycle = collectLiveHeapBytes()
+                val presentationBridge = benchmarkPresentationBridge(retainedUi)
 
                 println("TIMELINE_LIFECYCLE_BENCHMARK version=$LIFECYCLE_BENCHMARK_VERSION platform=$benchmarkPlatform")
                 println(
@@ -224,6 +230,16 @@ class TimelineDatabaseBenchmarkTest : RobolectricTest() {
                     "top_insert_full_chain",
                     BenchmarkSamples(longArrayOf(topInsertElapsed.inWholeNanoseconds), checksum),
                     "retained_rows=${LIFECYCLE_ROWS + 1}",
+                )
+                printMetric(
+                    "presentation_full_state_scan_proxy",
+                    presentationBridge.fullStateScan,
+                    "retained_rows=${retainedUi.size} repeats=$PRESENTATION_BRIDGE_REPEATS",
+                )
+                printMetric(
+                    "presentation_append_change_read",
+                    presentationBridge.appendChangeRead,
+                    "retained_rows=${retainedUi.size} inserted_rows=$PAGE_SIZE repeats=$PRESENTATION_BRIDGE_REPEATS",
                 )
                 printHeap("lifecycle_stable_prefix", heapWithStablePrefix)
                 printHeap("lifecycle_complete", heapAfterLifecycle)
@@ -458,6 +474,66 @@ class TimelineDatabaseBenchmarkTest : RobolectricTest() {
             }
         return StablePrefixBenchmarkResult(samples = samples, retainedRows = retainedRows)
     }
+
+    /**
+     * Cross-platform algorithmic proxy for the UIKit bridge. It deliberately excludes Swift/K/N
+     * interop overhead, so Instruments remains the authority for absolute iOS cost.
+     */
+    private suspend fun benchmarkPresentationBridge(items: List<UiTimelineV2>): PresentationBridgeBenchmarkResult {
+        val mapper = PagingPresentationMapper<UiTimelineV2> { it.toPresentationItem() }
+        val presentedItems = items.map(mapper::map).toPersistentList()
+        val appendStart = presentedItems.size - PAGE_SIZE
+        val tracker = PagingPresentationTracker(initialItems = presentedItems.subList(0, appendStart).toPersistentList())
+        val appended = presentedItems.subList(appendStart, presentedItems.size)
+        val appendChange =
+            requireNotNull(
+                tracker
+                    .appendOrRefresh(
+                        startIndex = appendStart,
+                        inserted = appended,
+                        newItems = ItemSnapshotList(0, 0, items),
+                        mapper = mapper,
+                        hasPlaceholders = false,
+                    ).change,
+            )
+        assertEquals(PAGE_SIZE, appendChange.replacement?.insertedCount)
+
+        val fullStateScan =
+            measureSamples {
+                var result = 0L
+                repeat(PRESENTATION_BRIDGE_REPEATS) {
+                    items.forEach { item ->
+                        result = result * 31 + item.itemKey.hashCode() + item.renderHash
+                    }
+                }
+                result
+            }
+        val appendChangeRead =
+            measureSamples {
+                var result = 0L
+                repeat(PRESENTATION_BRIDGE_REPEATS) {
+                    val replacement = requireNotNull(appendChange.replacement)
+                    repeat(replacement.insertedCount) { index ->
+                        val item = requireNotNull(replacement.insertedItemAt(index))
+                        result = result * 31 + item.key.hashCode() + item.renderHash
+                    }
+                }
+                result
+            }
+        return PresentationBridgeBenchmarkResult(
+            fullStateScan = fullStateScan,
+            appendChangeRead = appendChangeRead,
+        )
+    }
+
+    private fun UiTimelineV2.toPresentationItem(): PagingPresentationItem =
+        PagingPresentationItem(
+            key =
+                itemKey
+                    ?.takeIf { it.isNotEmpty() }
+                    ?: listOf(itemType, accountType.toString(), statusKey.toString()).joinToString(":"),
+            renderHash = renderHash,
+        )
 
     private suspend fun createTimelineItems(
         pagingKey: String,
@@ -764,9 +840,14 @@ class TimelineDatabaseBenchmarkTest : RobolectricTest() {
         val retainedRows: List<DbPagingTimelineWithStatus>,
     )
 
+    private data class PresentationBridgeBenchmarkResult(
+        val fullStateScan: BenchmarkSamples,
+        val appendChangeRead: BenchmarkSamples,
+    )
+
     private companion object {
         const val BENCHMARK_VERSION = 2
-        const val LIFECYCLE_BENCHMARK_VERSION = 2
+        const val LIFECYCLE_BENCHMARK_VERSION = 3
         const val BENCHMARK_PAGING_KEY = "timeline-database-benchmark"
         const val WARMUP_PAGING_KEY = "timeline-database-benchmark-warmup"
         const val LIFECYCLE_PAGING_KEY = "timeline-lifecycle-benchmark"
@@ -787,6 +868,7 @@ class TimelineDatabaseBenchmarkTest : RobolectricTest() {
         const val MEASURE_ITERATIONS = 7
         const val REWRITE_ITERATIONS = 3
         const val WINDOW_MEASURE_ITERATIONS = 3
+        const val PRESENTATION_BRIDGE_REPEATS = 100
 
         val PAGE_OFFSETS = listOf(0, 240, 480)
         val PAGE_WINDOW_LIMITS = listOf(20, 100, 500)

--- a/shared/src/commonTest/kotlin/dev/dimension/flare/data/database/cache/mapper/MicroblogTest.kt
+++ b/shared/src/commonTest/kotlin/dev/dimension/flare/data/database/cache/mapper/MicroblogTest.kt
@@ -8,6 +8,7 @@ import dev.dimension.flare.RobolectricTest
 import dev.dimension.flare.common.Locale
 import dev.dimension.flare.common.TestFormatter
 import dev.dimension.flare.data.database.cache.CacheDatabase
+import dev.dimension.flare.data.database.cache.loadTimelinePage
 import dev.dimension.flare.data.database.cache.model.DbPagingTimeline
 import dev.dimension.flare.data.database.cache.model.DbPagingTimelineWithStatus
 import dev.dimension.flare.data.database.cache.model.DbStatus
@@ -28,6 +29,7 @@ import dev.dimension.flare.data.datasource.microblog.ActionMenu
 import dev.dimension.flare.data.datasource.microblog.paging.TimelineDbPageCache
 import dev.dimension.flare.data.datasource.microblog.paging.TimelineDbPageLoader
 import dev.dimension.flare.data.datasource.microblog.paging.TimelinePagingMapper
+import dev.dimension.flare.data.datasource.microblog.paging.TimelineUiMapperCache
 import dev.dimension.flare.data.datastore.model.AppSettings
 import dev.dimension.flare.data.translation.PreTranslationStoreSupport
 import dev.dimension.flare.data.translation.cacheKey
@@ -63,6 +65,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.time.Clock
 
@@ -182,6 +186,9 @@ class MicroblogTest : RobolectricTest() {
             val savedUser = db.userDao().findByKey(userKey).first()
             assertNotNull(savedUser)
             assertEquals("New Name", savedUser.content.name.raw)
+            val savedStatus = db.statusDao().get(statusKey, AccountType.Specific(accountKey)).first()
+            assertNotNull(savedStatus)
+            assertEquals("New Name", rootPostOf(savedStatus.content).user?.name?.raw)
         }
 
     @Test
@@ -498,6 +505,384 @@ class MicroblogTest : RobolectricTest() {
                 emptyList(),
                 loader.load(offset = 2, limit = 1).map { it.status.status.data.id },
             )
+        }
+
+    @Test
+    fun timelineStorageIdsAreStableForEquivalentMappings() =
+        runTest {
+            val accountKey = MicroBlogKey(id = "account-stable-id", host = "test.com")
+            val user = createUser(MicroBlogKey(id = "user-stable-id", host = "test.com"), "User")
+            val quote =
+                createPost(
+                    accountKey = accountKey,
+                    user = user,
+                    statusKey = MicroBlogKey(id = "quote-stable-id", host = "test.com"),
+                    text = "quote",
+                )
+            val item =
+                timelinePostItem(
+                    post =
+                        createPost(
+                            accountKey = accountKey,
+                            user = user,
+                            statusKey = MicroBlogKey(id = "root-stable-id", host = "test.com"),
+                            text = "root",
+                        ),
+                    quotes = listOf(quote),
+                )
+
+            val first = TimelinePagingMapper.toDb(item, pagingKey = "home", sortId = 10)
+            val second = TimelinePagingMapper.toDb(item, pagingKey = "home", sortId = 10)
+
+            assertEquals(first.timeline._id, second.timeline._id)
+            assertEquals(
+                first.status.references.map { it.reference._id },
+                second.status.references.map { it.reference._id },
+            )
+            assertEquals(
+                first.presentationReferences.map { it.reference._id },
+                second.presentationReferences.map { it.reference._id },
+            )
+        }
+
+    @Test
+    fun timelineUiMapperCacheReusesOnlyUnchangedDatabaseItemsAndDisplayOptions() =
+        runTest {
+            val accountKey = MicroBlogKey(id = "account-ui-cache", host = "test.com")
+            val user = createUser(MicroBlogKey(id = "user-ui-cache", host = "test.com"), "User")
+            val mapped =
+                TimelinePagingMapper.toDb(
+                    createPost(
+                        accountKey = accountKey,
+                        user = user,
+                        statusKey = MicroBlogKey(id = "status-ui-cache", host = "test.com"),
+                        text = "cached",
+                    ),
+                    pagingKey = "home",
+                    sortId = 1,
+                )
+            val options = translationDisplayOptions()
+            val cache = TimelineUiMapperCache(maxSize = 2)
+
+            val first = cache.toUi(mapped, "home", options)
+            assertSame(first, cache.toUi(mapped, "home", options))
+            assertNotSame(
+                first,
+                cache.toUi(mapped, "home", options.copy(autoDisplayEnabled = false)),
+            )
+            assertNotSame(
+                first,
+                cache.toUi(mapped.copy(timeline = mapped.timeline.copy(sortId = 2)), "home", options),
+            )
+        }
+
+    @Test
+    fun batchTimelineMappingMatchesSingleMappingAndInternsSharedReferenceStatuses() =
+        runTest {
+            val accountKey = MicroBlogKey(id = "account-batch-map", host = "test.com")
+            val user = createUser(MicroBlogKey(id = "user-batch-map", host = "test.com"), "User")
+            val sharedQuote =
+                createPost(
+                    accountKey = accountKey,
+                    user = user,
+                    statusKey = MicroBlogKey(id = "shared-quote-batch-map", host = "test.com"),
+                    text = "shared quote",
+                )
+            val items =
+                listOf("first", "second").map { id ->
+                    timelinePostItem(
+                        post =
+                            createPost(
+                                accountKey = accountKey,
+                                user = user,
+                                statusKey = MicroBlogKey(id = "$id-batch-map", host = "test.com"),
+                                text = id,
+                            ),
+                        quotes = listOf(sharedQuote),
+                    )
+                }
+            val individual =
+                items.mapIndexed { index, item ->
+                    TimelinePagingMapper.toDb(item, pagingKey = "home", sortId = index.toLong())
+                }
+
+            val batch =
+                TimelinePagingMapper.toDb(
+                    data = items,
+                    pagingKey = "home",
+                    sortIds = listOf(0L, 1L),
+                )
+
+            assertEquals(individual, batch)
+            assertSame(
+                batch[0].presentationReferences.single().status,
+                batch[1].presentationReferences.single().status,
+            )
+        }
+
+    @Test
+    fun explicitTimelineHydrationSharesReferencedStatusesAndFiltersTranslationType() =
+        runTest {
+            val accountKey = MicroBlogKey(id = "account-hydration", host = "test.com")
+            val user = createUser(MicroBlogKey(id = "user-hydration", host = "test.com"), "User")
+            val quote =
+                createPost(
+                    accountKey = accountKey,
+                    user = user,
+                    statusKey = MicroBlogKey(id = "quote-hydration", host = "test.com"),
+                    text = "quote",
+                )
+            val mapped =
+                TimelinePagingMapper.toDb(
+                    data =
+                        timelinePostItem(
+                            post =
+                                createPost(
+                                    accountKey = accountKey,
+                                    user = user,
+                                    statusKey = MicroBlogKey(id = "root-hydration", host = "test.com"),
+                                    text = "root",
+                                ),
+                            quotes = listOf(quote),
+                        ),
+                    pagingKey = "home",
+                    sortId = 10,
+                )
+            saveToDatabase(db, listOf(mapped))
+            val rootStatusId = mapped.status.status.data.id
+            db.translationDao().insertAll(
+                listOf(
+                    DbTranslation(
+                        entityType = TranslationEntityType.Status,
+                        entityKey = rootStatusId,
+                        targetLanguage = "zh-CN",
+                        sourceHash = "status-source",
+                        status = TranslationStatus.Completed,
+                        updatedAt = 1,
+                    ),
+                    DbTranslation(
+                        entityType = TranslationEntityType.Profile,
+                        entityKey = rootStatusId,
+                        targetLanguage = "zh-CN",
+                        sourceHash = "profile-source",
+                        status = TranslationStatus.Completed,
+                        updatedAt = 1,
+                    ),
+                ),
+            )
+
+            val loaded = db.loadTimelinePage(pagingKey = "home", offset = 0, limit = 20).single()
+            val semanticQuote =
+                loaded.status.references.single { it.reference.referenceType == ReferenceType.Quote }
+            val presentationQuote =
+                loaded.presentationReferences.single {
+                    it.reference.presentationType.name == "Quote"
+                }
+
+            assertSame(semanticQuote.status, presentationQuote.status)
+            assertEquals(listOf(TranslationEntityType.Status), loaded.statusTranslations.map { it.entityType })
+        }
+
+    @Test
+    fun timelinePageCacheKeepsHighWaterMarkAndReusesUnchangedItemsByStatusId() =
+        runTest {
+            val accountKey = MicroBlogKey(id = "account-cache", host = "test.com")
+            val user = createUser(MicroBlogKey(id = "user-cache", host = "test.com"), "User")
+
+            suspend fun mapped(
+                id: String,
+                text: String,
+                sortId: Long,
+            ) = TimelinePagingMapper.toDb(
+                data =
+                    createPost(
+                        accountKey = accountKey,
+                        user = user,
+                        statusKey = MicroBlogKey(id = id, host = "test.com"),
+                        text = text,
+                    ),
+                pagingKey = "home",
+                sortId = sortId,
+            )
+
+            val first = mapped(id = "first-cache", text = "first", sortId = 10)
+            val second = mapped(id = "second-cache", text = "second", sortId = 20)
+            val third = mapped(id = "third-cache", text = "third", sortId = 30)
+            saveToDatabase(db, listOf(first, second, third))
+
+            val loader = TimelineDbPageLoader(db, "home", TimelineDbPageCache())
+            val firstPage = loader.load(offset = 0, limit = 2)
+            val appendedPage = loader.load(offset = 2, limit = 1)
+            val refreshedPrefix = loader.load(offset = 0, limit = 1)
+
+            assertEquals(listOf(first.timeline.statusId, second.timeline.statusId), firstPage.map { it.timeline.statusId })
+            assertEquals(listOf(third.timeline.statusId), appendedPage.map { it.timeline.statusId })
+            assertEquals(
+                listOf(first.timeline.statusId, second.timeline.statusId, third.timeline.statusId),
+                refreshedPrefix.map { it.timeline.statusId },
+            )
+            assertSame(firstPage[0], refreshedPrefix[0])
+            assertSame(firstPage[1], refreshedPrefix[1])
+            assertSame(appendedPage[0], refreshedPrefix[2])
+
+            val inserted = mapped(id = "inserted-cache", text = "inserted", sortId = 5)
+            saveToDatabase(db, listOf(inserted))
+            val afterInsert = loader.load(offset = 0, limit = 1)
+
+            assertEquals(
+                listOf(
+                    inserted.timeline.statusId,
+                    first.timeline.statusId,
+                    second.timeline.statusId,
+                    third.timeline.statusId,
+                ),
+                afterInsert.map { it.timeline.statusId },
+            )
+            assertSame(refreshedPrefix[0], afterInsert[1])
+            assertSame(refreshedPrefix[1], afterInsert[2])
+            assertSame(refreshedPrefix[2], afterInsert[3])
+
+            val changedSecond = mapped(id = "second-cache", text = "second changed", sortId = 20)
+            saveToDatabase(db, listOf(changedSecond))
+            val afterChange = loader.load(offset = 0, limit = 4)
+
+            assertSame(afterInsert[0], afterChange[0])
+            assertSame(afterInsert[1], afterChange[1])
+            assertNotSame(afterInsert[2], afterChange[2])
+            assertSame(afterInsert[3], afterChange[3])
+            assertEquals(
+                "second changed",
+                rootPostOf(
+                    afterChange[2]
+                        .status.status.data.content,
+                ).content.original.raw,
+            )
+        }
+
+    @Test
+    fun timelinePageCacheRefreshesReferencedContentAndTranslationWithoutReplacingUnchangedRoots() =
+        runTest {
+            val accountKey = MicroBlogKey(id = "account-cache-dependency", host = "test.com")
+            val user = createUser(MicroBlogKey(id = "user-cache-dependency", host = "test.com"), "User")
+            val quote =
+                createPost(
+                    accountKey = accountKey,
+                    user = user,
+                    statusKey = MicroBlogKey(id = "quote-cache-dependency", host = "test.com"),
+                    text = "quote original",
+                )
+            val firstRoot =
+                createPost(
+                    accountKey = accountKey,
+                    user = user,
+                    statusKey = MicroBlogKey(id = "first-cache-dependency", host = "test.com"),
+                    text = "first root",
+                )
+            val secondRoot =
+                createPost(
+                    accountKey = accountKey,
+                    user = user,
+                    statusKey = MicroBlogKey(id = "second-cache-dependency", host = "test.com"),
+                    text = "second root",
+                )
+            val first = TimelinePagingMapper.toDb(timelinePostItem(firstRoot, quotes = listOf(quote)), "home", sortId = 10)
+            val second = TimelinePagingMapper.toDb(secondRoot, "home", sortId = 20)
+            saveToDatabase(db, listOf(first, second))
+
+            val loader = TimelineDbPageLoader(db, "home", TimelineDbPageCache())
+            val initial = loader.load(offset = 0, limit = 2)
+
+            val updatedQuote = quote.copy(content = UiTranslatableText("quote changed".toUiPlainText()))
+            val changedFirst =
+                TimelinePagingMapper.toDb(
+                    timelinePostItem(firstRoot, quotes = listOf(updatedQuote)),
+                    "home",
+                    sortId = 10,
+                )
+            saveToDatabase(db, listOf(changedFirst))
+            val afterContentChange = loader.load(offset = 0, limit = 2)
+
+            assertNotSame(initial[0], afterContentChange[0])
+            assertSame(initial[1], afterContentChange[1])
+            val changedUi =
+                assertIs<UiTimelineV2.TimelinePostItem>(
+                    TimelinePagingMapper.toUi(afterContentChange[0], "home", translationDisplayOptions()),
+                )
+            assertEquals(
+                "quote changed",
+                changedUi.presentation.quotes
+                    .single()
+                    .content.original.raw,
+            )
+
+            val quoteStatusId =
+                changedFirst.presentationReferences
+                    .single()
+                    .reference.referenceStatusId
+            val sourcePayload = checkNotNull(updatedQuote.translationPayload())
+            db.translationDao().insert(
+                DbTranslation(
+                    entityType = TranslationEntityType.Status,
+                    entityKey = quoteStatusId,
+                    targetLanguage = Locale.language,
+                    sourceHash = sourcePayload.sourceHash(googleTranslationProviderCacheKey),
+                    status = TranslationStatus.Completed,
+                    payload = TranslationPayload(content = "quote translated".toUiPlainText()),
+                    updatedAt = 1,
+                ),
+            )
+            val afterTranslation = loader.load(offset = 0, limit = 2)
+
+            assertNotSame(afterContentChange[0], afterTranslation[0])
+            assertSame(afterContentChange[1], afterTranslation[1])
+            val translatedUi =
+                assertIs<UiTimelineV2.TimelinePostItem>(
+                    TimelinePagingMapper.toUi(afterTranslation[0], "home", translationDisplayOptions()),
+                )
+            assertEquals(
+                "quote translated",
+                translatedUi.presentation.quotes
+                    .single()
+                    .content.translation
+                    ?.raw,
+            )
+
+            db.statusDao().delete(
+                statusKey = updatedQuote.statusKey,
+                accountType = AccountType.Specific(accountKey),
+            )
+            val afterReferencedStatusDelete = loader.load(offset = 0, limit = 2)
+            assertNotSame(afterTranslation[0], afterReferencedStatusDelete[0])
+            assertSame(afterTranslation[1], afterReferencedStatusDelete[1])
+            val withoutReferencedStatus =
+                assertIs<UiTimelineV2.TimelinePostItem>(
+                    TimelinePagingMapper.toUi(afterReferencedStatusDelete[0], "home", translationDisplayOptions()),
+                )
+            assertTrue(withoutReferencedStatus.presentation.quotes.isEmpty())
+
+            saveToDatabase(db, listOf(changedFirst))
+            val afterReferencedStatusRestore = loader.load(offset = 0, limit = 2)
+            assertNotSame(afterReferencedStatusDelete[0], afterReferencedStatusRestore[0])
+            assertSame(afterReferencedStatusDelete[1], afterReferencedStatusRestore[1])
+            val restoredReference =
+                assertIs<UiTimelineV2.TimelinePostItem>(
+                    TimelinePagingMapper.toUi(afterReferencedStatusRestore[0], "home", translationDisplayOptions()),
+                )
+            assertEquals(1, restoredReference.presentation.quotes.size)
+
+            saveToDatabase(
+                db,
+                listOf(TimelinePagingMapper.toDb(firstRoot, "home", sortId = 10)),
+            )
+            val afterReferenceRemoval = loader.load(offset = 0, limit = 2)
+
+            assertNotSame(afterReferencedStatusRestore[0], afterReferenceRemoval[0])
+            assertSame(afterReferencedStatusRestore[1], afterReferenceRemoval[1])
+            val withoutQuoteUi =
+                assertIs<UiTimelineV2.TimelinePostItem>(
+                    TimelinePagingMapper.toUi(afterReferenceRemoval[0], "home", translationDisplayOptions()),
+                )
+            assertTrue(withoutQuoteUi.presentation.quotes.isEmpty())
         }
 
     @Test

--- a/shared/src/commonTest/kotlin/dev/dimension/flare/data/datasource/microblog/MixedRemoteMediatorTest.kt
+++ b/shared/src/commonTest/kotlin/dev/dimension/flare/data/datasource/microblog/MixedRemoteMediatorTest.kt
@@ -15,6 +15,7 @@ import dev.dimension.flare.common.encodeJson
 import dev.dimension.flare.createTestFileSystem
 import dev.dimension.flare.createTestRootPath
 import dev.dimension.flare.data.database.cache.CacheDatabase
+import dev.dimension.flare.data.database.cache.loadTimelinePage
 import dev.dimension.flare.data.database.cache.mapper.saveToDatabase
 import dev.dimension.flare.data.database.cache.model.DbPagingKey
 import dev.dimension.flare.data.database.cache.model.DbPagingTimelineWithStatus
@@ -599,8 +600,7 @@ class MixedRemoteMediatorTest : RobolectricTest() {
                     "https://example.com/b_2000",
                 ),
                 db
-                    .pagingTimelineDao()
-                    .getTimelinePage(refreshMediator.pagingKey, offset = 0, limit = 20)
+                    .loadTimelinePage(refreshMediator.pagingKey, offset = 0, limit = 20)
                     .mapNotNull { (it.status.status.data.content as? UiTimelineV2.Feed)?.url },
             )
             assertEquals(listOf<PagingRequest>(PagingRequest.Refresh, PagingRequest.Append("a_next")), first.requests)
@@ -727,7 +727,7 @@ class MixedRemoteMediatorTest : RobolectricTest() {
             assertTrue(appendResult is androidx.paging.RemoteMediator.MediatorResult.Success)
 
             val page =
-                db.pagingTimelineDao().getTimelinePage(
+                db.loadTimelinePage(
                     pagingKey = appendMediator.pagingKey,
                     offset = 0,
                     limit = 20,
@@ -804,7 +804,7 @@ class MixedRemoteMediatorTest : RobolectricTest() {
                 loader.requests,
             )
             val page =
-                db.pagingTimelineDao().getTimelinePage(
+                db.loadTimelinePage(
                     pagingKey = loader.pagingKey,
                     offset = 0,
                     limit = 20,

--- a/shared/src/commonTest/kotlin/dev/dimension/flare/data/datasource/microblog/PostEventHandlerTest.kt
+++ b/shared/src/commonTest/kotlin/dev/dimension/flare/data/datasource/microblog/PostEventHandlerTest.kt
@@ -5,6 +5,7 @@ import dev.dimension.flare.RobolectricTest
 import dev.dimension.flare.common.SerializableImmutableList
 import dev.dimension.flare.common.TestFormatter
 import dev.dimension.flare.data.database.cache.CacheDatabase
+import dev.dimension.flare.data.database.cache.loadTimelinePageIdentities
 import dev.dimension.flare.data.database.cache.model.DbPagingTimeline
 import dev.dimension.flare.data.database.cache.model.DbStatus
 import dev.dimension.flare.data.database.createDatabaseDriver
@@ -123,8 +124,7 @@ class PostEventHandlerTest : RobolectricTest() {
             )
             val beforeIdentity =
                 db
-                    .pagingTimelineDao()
-                    .getTimelinePageIdentities(pagingKey = "home", offset = 0, limit = 1)
+                    .loadTimelinePageIdentities(pagingKey = "home", offset = 0, limit = 1)
                     .single()
 
             handler = PostEventHandler(accountType = AccountType.Specific(accountKey), handler = fakeRemoteHandler)
@@ -136,12 +136,11 @@ class PostEventHandlerTest : RobolectricTest() {
             val updatedPost = saved.content as UiTimelineV2.Post
             val afterIdentity =
                 db
-                    .pagingTimelineDao()
-                    .getTimelinePageIdentities(pagingKey = "home", offset = 0, limit = 1)
+                    .loadTimelinePageIdentities(pagingKey = "home", offset = 0, limit = 1)
                     .single()
-            assertNotEquals(beforeIdentity.rootRenderHash, afterIdentity.rootRenderHash)
+            assertNotEquals(beforeIdentity.rootContentHash, afterIdentity.rootContentHash)
             assertEquals(updatedPost.renderHash, saved.renderHash)
-            assertEquals(saved.renderHash, afterIdentity.rootRenderHash)
+            assertEquals(saved.contentHash, afterIdentity.rootContentHash)
         }
 
     @Test

--- a/shared/src/jvmTest/kotlin/dev/dimension/flare/DatabaseHelper.jvm.kt
+++ b/shared/src/jvmTest/kotlin/dev/dimension/flare/DatabaseHelper.jvm.kt
@@ -4,14 +4,25 @@ import androidx.room3.Room
 import androidx.room3.RoomDatabase
 import dev.dimension.flare.data.database.app.AppDatabase
 import dev.dimension.flare.data.database.cache.CacheDatabase
+import dev.dimension.flare.data.database.cache.TimelineDependencyRevisionCallback
 import kotlin.reflect.KClass
 
 @Suppress("UNCHECKED_CAST")
 internal actual fun <T : RoomDatabase> Room.memoryDatabaseBuilder(databaseClass: KClass<T>): RoomDatabase.Builder<T> =
     when (databaseClass) {
-        AppDatabase::class -> Room.inMemoryDatabaseBuilder<AppDatabase>()
-        CacheDatabase::class -> Room.inMemoryDatabaseBuilder<CacheDatabase>()
-        else -> error("Unsupported test database: ${databaseClass.qualifiedName}")
+        AppDatabase::class -> {
+            Room.inMemoryDatabaseBuilder<AppDatabase>()
+        }
+
+        CacheDatabase::class -> {
+            Room
+                .inMemoryDatabaseBuilder<CacheDatabase>()
+                .addCallback(TimelineDependencyRevisionCallback)
+        }
+
+        else -> {
+            error("Unsupported test database: ${databaseClass.qualifiedName}")
+        }
     } as RoomDatabase.Builder<T>
 
 actual open class RobolectricTest actual constructor()

--- a/shared/src/jvmTest/kotlin/dev/dimension/flare/benchmark/BenchmarkRuntime.jvm.kt
+++ b/shared/src/jvmTest/kotlin/dev/dimension/flare/benchmark/BenchmarkRuntime.jvm.kt
@@ -1,0 +1,9 @@
+package dev.dimension.flare.benchmark
+
+internal actual val benchmarkPlatform: String = "jvm-bundled-sqlite"
+
+internal actual fun collectLiveHeapBytes(): Long? {
+    System.gc()
+    val runtime = Runtime.getRuntime()
+    return runtime.totalMemory() - runtime.freeMemory()
+}

--- a/shared/src/wasmJsTest/kotlin/dev/dimension/flare/DatabaseHelper.wasmJs.kt
+++ b/shared/src/wasmJsTest/kotlin/dev/dimension/flare/DatabaseHelper.wasmJs.kt
@@ -4,14 +4,25 @@ import androidx.room3.Room
 import androidx.room3.RoomDatabase
 import dev.dimension.flare.data.database.app.AppDatabase
 import dev.dimension.flare.data.database.cache.CacheDatabase
+import dev.dimension.flare.data.database.cache.TimelineDependencyRevisionCallback
 import kotlin.reflect.KClass
 
 @Suppress("UNCHECKED_CAST")
 internal actual fun <T : RoomDatabase> Room.memoryDatabaseBuilder(databaseClass: KClass<T>): RoomDatabase.Builder<T> =
     when (databaseClass) {
-        AppDatabase::class -> Room.inMemoryDatabaseBuilder<AppDatabase>()
-        CacheDatabase::class -> Room.inMemoryDatabaseBuilder<CacheDatabase>()
-        else -> error("Unsupported test database: ${databaseClass.simpleName}")
+        AppDatabase::class -> {
+            Room.inMemoryDatabaseBuilder<AppDatabase>()
+        }
+
+        CacheDatabase::class -> {
+            Room
+                .inMemoryDatabaseBuilder<CacheDatabase>()
+                .addCallback(TimelineDependencyRevisionCallback)
+        }
+
+        else -> {
+            error("Unsupported test database: ${databaseClass.simpleName}")
+        }
     } as RoomDatabase.Builder<T>
 
 actual open class RobolectricTest actual constructor()

--- a/shared/src/wasmJsTest/kotlin/dev/dimension/flare/benchmark/BenchmarkRuntime.wasmJs.kt
+++ b/shared/src/wasmJsTest/kotlin/dev/dimension/flare/benchmark/BenchmarkRuntime.wasmJs.kt
@@ -1,0 +1,5 @@
+package dev.dimension.flare.benchmark
+
+internal actual val benchmarkPlatform: String = "wasm-js-web-sqlite"
+
+internal actual fun collectLiveHeapBytes(): Long? = null


### PR DESCRIPTION
## Summary

- avoid repeated timeline cache writes and relation hydration using stable content hashes, dependency revisions, batched page readers, and selective object reuse
- preserve the non-Android stable-prefix behavior while reusing unchanged database and UI models
- expose versioned Paging3 presentation changes from common code so UIKit can apply incremental snapshots without traversing the complete `PagingState`
- add cross-platform lifecycle benchmarks and regression coverage for refresh, append, prepend, drop, translation, and top insertion

## Performance

Representative macOS Kotlin/Native benchmark runs showed:

- identity scan: about 95% faster
- stable-prefix refresh: about 96% faster
- changed full-chain refresh: about 42% faster
- incremental presentation-change processing: about 13.8x faster than the full-state scan proxy

Absolute iOS bridge and VM Tag 246 impact should still be validated with Instruments.

## Validation

- JVM timeline, presenter, and paging-presentation tests
- macOS Kotlin/Native paging-presentation and lifecycle benchmark tests
- commonMain/commonTest ktlint checks
- iOS Simulator Kotlin compilation
- full iOS Xcode scheme build

## Scope

This PR keeps the existing presenter/UI interface and stable-prefix behavior. It does not yet implement the proposed end-to-end Projection + Paging3 read model; that remains a follow-up optimization.