### PR TITLE
feat(android): user-selectable playback speed and open-in-external-app for media viewer

### DIFF
--- a/app/src/main/java/dev/dimension/flare/ui/screen/media/StatusMediaScreen.kt
+++ b/app/src/main/java/dev/dimension/flare/ui/screen/media/StatusMediaScreen.kt
@@ -3,6 +3,7 @@ package dev.dimension.flare.ui.screen.media
 import android.Manifest
 import android.content.ClipData
 import android.content.Context
+import android.content.Intent
 import android.os.Build
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
@@ -53,6 +54,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -81,6 +83,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.media3.common.C
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
@@ -108,6 +111,7 @@ import compose.icons.fontawesomeicons.solid.GaugeHigh
 import compose.icons.fontawesomeicons.solid.Pause
 import compose.icons.fontawesomeicons.solid.Play
 import compose.icons.fontawesomeicons.solid.ShareNodes
+import compose.icons.fontawesomeicons.solid.UpRightFromSquare
 import compose.icons.fontawesomeicons.solid.Xmark
 import dev.dimension.flare.R
 import dev.dimension.flare.common.AndroidDownloadManager
@@ -117,6 +121,7 @@ import dev.dimension.flare.model.AccountType
 import dev.dimension.flare.model.MicroBlogKey
 import dev.dimension.flare.ui.component.FAIcon
 import dev.dimension.flare.ui.component.Glassify
+import dev.dimension.flare.ui.component.LocalGlobalAppearance
 import dev.dimension.flare.ui.component.LocalTimelineAppearance
 import dev.dimension.flare.ui.component.SurfaceBindingManager
 import dev.dimension.flare.ui.component.VideoPlayer
@@ -263,6 +268,32 @@ internal fun MediaViewerScreen(
             context = context,
         )
     }
+    val openExternal: (UiMedia) -> Unit = { media ->
+        val mimeType =
+            when (media) {
+                is UiMedia.Video -> "video/*"
+                is UiMedia.Audio -> "audio/*"
+                is UiMedia.Gif ->
+                    if (media.url.contains(".mp4", ignoreCase = true) ||
+                        media.url.contains(".webm", ignoreCase = true)
+                    ) {
+                        "video/*"
+                    } else {
+                        "image/*"
+                    }
+
+                is UiMedia.Image -> "image/*"
+            }
+        val intent =
+            Intent(Intent.ACTION_VIEW).apply {
+                setDataAndType(media.url.toUri(), mimeType)
+            }
+        try {
+            context.startActivity(Intent.createChooser(intent, null))
+        } catch (e: Exception) {
+            Toast.makeText(context, e.message, Toast.LENGTH_SHORT).show()
+        }
+    }
     val pagerState =
         rememberPagerState(
             initialPage = initialIndex,
@@ -274,16 +305,22 @@ internal fun MediaViewerScreen(
                 }
             },
         )
-    var playbackSpeed by remember { mutableFloatStateOf(NORMAL_PLAYBACK_SPEED) }
+    val defaultPlaybackSpeed =
+        LocalGlobalAppearance.current.mediaPlaybackSpeed.coerceIn(
+            NORMAL_PLAYBACK_SPEED,
+            MAX_PLAYBACK_SPEED,
+        )
+    var playbackSpeed by remember { mutableFloatStateOf(defaultPlaybackSpeed) }
+    var isFastPlayback by remember { mutableStateOf(false) }
     MediaLandscapeEffect(
         enabled = state.isLandscapeViewing,
         originalOrientation = state.originalOrientation,
         setOriginalOrientation = state::setOriginalOrientation,
     )
-    LaunchedEffect(pagerState.currentPage) {
+    LaunchedEffect(pagerState.currentPage, defaultPlaybackSpeed) {
         state.setCurrentPage(pagerState.currentPage)
-        playbackSpeed = NORMAL_PLAYBACK_SPEED
-        surfaceBindingManager.player.setPlaybackSpeed(NORMAL_PLAYBACK_SPEED)
+        playbackSpeed = defaultPlaybackSpeed
+        surfaceBindingManager.player.setPlaybackSpeed(defaultPlaybackSpeed)
     }
     FlareTheme(darkTheme = true) {
         val swiperState =
@@ -414,6 +451,10 @@ internal fun MediaViewerScreen(
                                                         onPlaybackSpeedChanged = {
                                                             playbackSpeed = it
                                                         },
+                                                        onFastPlaybackChanged = {
+                                                            isFastPlayback = it
+                                                        },
+                                                        baseSpeed = playbackSpeed,
                                                         modifier = Modifier.fillMaxSize(),
                                                     )
                                                 }
@@ -571,6 +612,19 @@ internal fun MediaViewerScreen(
                                             )
                                         }
                                     }
+                                    Glassify(
+                                        onClick = {
+                                            openExternal(current)
+                                        },
+                                        color = MaterialTheme.colorScheme.secondaryContainer,
+                                        modifier = Modifier.size(40.dp),
+                                        shape = CircleShape,
+                                    ) {
+                                        FAIcon(
+                                            FontAwesomeIcons.Solid.UpRightFromSquare,
+                                            contentDescription = stringResource(id = R.string.media_menu_open_external),
+                                        )
+                                    }
                                 }
                             }
                         }
@@ -581,11 +635,11 @@ internal fun MediaViewerScreen(
                             when {
                                 state.isLandscapeViewing -> {
                                     isCurrentVideo &&
-                                        (state.showUi || playbackSpeed > NORMAL_PLAYBACK_SPEED)
+                                        (state.showUi || isFastPlayback)
                                 }
 
                                 isCurrentVideo -> {
-                                    state.showUi || playbackSpeed > NORMAL_PLAYBACK_SPEED
+                                    state.showUi || isFastPlayback
                                 }
 
                                 else -> {
@@ -705,6 +759,10 @@ internal fun MediaViewerScreen(
                                             PlayerControl(
                                                 surfaceBindingManager.player,
                                                 playbackSpeed = playbackSpeed,
+                                                isFastPlayback = isFastPlayback,
+                                                onPlaybackSpeedChanged = {
+                                                    playbackSpeed = it
+                                                },
                                                 modifier =
                                                     Modifier
                                                         .widthIn(max = 480.dp),
@@ -898,6 +956,29 @@ internal fun MediaViewerScreen(
                         modifier =
                             Modifier
                                 .clickable {
+                                    openExternal(current)
+                                    state.setShowSheet(false)
+                                },
+                        leadingContent = {
+                            FAIcon(
+                                FontAwesomeIcons.Solid.UpRightFromSquare,
+                                contentDescription = null,
+                                modifier = Modifier.size(24.dp),
+                            )
+                        },
+                        colors =
+                            ListItemDefaults.colors(
+                                containerColor = Color.Transparent,
+                            ),
+                        elevation = ListItemDefaults.elevation(),
+                        content = {
+                            Text(stringResource(id = R.string.media_menu_open_external))
+                        },
+                    )
+                    ListItem(
+                        modifier =
+                            Modifier
+                                .clickable {
                                     scope.launch {
                                         val url = current.url
                                         clipboard.setClipEntry(
@@ -996,9 +1077,12 @@ private fun PlayerControl(
     player: ExoPlayer,
     modifier: Modifier = Modifier,
     playbackSpeed: Float = NORMAL_PLAYBACK_SPEED,
+    isFastPlayback: Boolean = false,
+    onPlaybackSpeedChanged: (Float) -> Unit = {},
 ) {
     val playPauseButtonState = rememberPlayPauseButtonState(player)
     var isLoaded by remember { mutableStateOf(false) }
+    var showSpeedSelector by remember { mutableStateOf(false) }
     LaunchedEffect(player) {
         while (!isLoaded) {
             isLoaded = player.isPlaying
@@ -1011,7 +1095,7 @@ private fun PlayerControl(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         AnimatedVisibility(
-            visible = playbackSpeed > NORMAL_PLAYBACK_SPEED,
+            visible = isFastPlayback,
             enter = fadeIn(),
             exit = fadeOut(),
         ) {
@@ -1105,7 +1189,45 @@ private fun PlayerControl(
                     modifier = Modifier.weight(1f),
                 )
                 Text(time)
+                TextButton(
+                    onClick = {
+                        showSpeedSelector = !showSpeedSelector
+                    },
+                ) {
+                    Text("${playbackSpeed.formatSpeed()}x")
+                }
                 Spacer(Modifier.width(screenHorizontalPadding))
+            }
+        }
+        AnimatedVisibility(
+            visible = showSpeedSelector && isLoaded,
+            enter = fadeIn(),
+            exit = fadeOut(),
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = screenHorizontalPadding),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                FAIcon(
+                    FontAwesomeIcons.Solid.GaugeHigh,
+                    contentDescription = stringResource(id = R.string.media_playback_speed),
+                    modifier = Modifier.size(16.dp),
+                )
+                Slider(
+                    value = playbackSpeed,
+                    onValueChange = {
+                        val speed = (it * 10).roundToInt() / 10f
+                        if (speed != playbackSpeed) {
+                            player.setPlaybackSpeed(speed)
+                            onPlaybackSpeedChanged(speed)
+                        }
+                    },
+                    valueRange = NORMAL_PLAYBACK_SPEED..MAX_PLAYBACK_SPEED,
+                    steps = 29,
+                    modifier = Modifier.weight(1f),
+                )
+                Text("${playbackSpeed.formatSpeed()}x")
             }
         }
     }
@@ -1123,14 +1245,19 @@ private fun VideoGestureOverlay(
     player: ExoPlayer,
     onClick: () -> Unit,
     onPlaybackSpeedChanged: (Float) -> Unit,
+    onFastPlaybackChanged: (Boolean) -> Unit,
+    baseSpeed: Float,
     modifier: Modifier = Modifier,
 ) {
     val currentOnClick by rememberUpdatedState(onClick)
     val currentOnPlaybackSpeedChanged by rememberUpdatedState(onPlaybackSpeedChanged)
+    val currentOnFastPlaybackChanged by rememberUpdatedState(onFastPlaybackChanged)
+    val currentBaseSpeed by rememberUpdatedState(baseSpeed)
     var seekFeedback by remember { mutableStateOf<SeekFeedback?>(null) }
     var seekFeedbackVersion by remember { mutableIntStateOf(0) }
     var fastPlaybackWasPlaying by remember { mutableStateOf(false) }
     var isFastPlayback by remember { mutableStateOf(false) }
+    var speedBeforeFastPlayback by remember { mutableFloatStateOf(NORMAL_PLAYBACK_SPEED) }
 
     fun showSeekFeedback(feedback: SeekFeedback) {
         seekFeedback = feedback
@@ -1140,22 +1267,26 @@ private fun VideoGestureOverlay(
     fun beginFastPlayback() {
         if (isFastPlayback) return
         fastPlaybackWasPlaying = player.isPlaying
-        player.setPlaybackSpeed(FAST_PLAYBACK_SPEED)
+        speedBeforeFastPlayback = currentBaseSpeed
+        val fastSpeed = maxOf(FAST_PLAYBACK_SPEED, currentBaseSpeed)
+        player.setPlaybackSpeed(fastSpeed)
         if (!player.isPlaying) {
             player.play()
         }
         isFastPlayback = true
-        currentOnPlaybackSpeedChanged(FAST_PLAYBACK_SPEED)
+        currentOnPlaybackSpeedChanged(fastSpeed)
+        currentOnFastPlaybackChanged(true)
     }
 
     fun endFastPlayback() {
         if (!isFastPlayback) return
-        player.setPlaybackSpeed(NORMAL_PLAYBACK_SPEED)
+        player.setPlaybackSpeed(speedBeforeFastPlayback)
         if (!fastPlaybackWasPlaying) {
             player.pause()
         }
         isFastPlayback = false
-        currentOnPlaybackSpeedChanged(NORMAL_PLAYBACK_SPEED)
+        currentOnPlaybackSpeedChanged(speedBeforeFastPlayback)
+        currentOnFastPlaybackChanged(false)
     }
 
     LaunchedEffect(seekFeedbackVersion) {
@@ -1168,8 +1299,9 @@ private fun VideoGestureOverlay(
     androidx.compose.runtime.DisposableEffect(player) {
         onDispose {
             if (isFastPlayback) {
-                player.setPlaybackSpeed(NORMAL_PLAYBACK_SPEED)
-                currentOnPlaybackSpeedChanged(NORMAL_PLAYBACK_SPEED)
+                player.setPlaybackSpeed(speedBeforeFastPlayback)
+                currentOnPlaybackSpeedChanged(speedBeforeFastPlayback)
+                currentOnFastPlaybackChanged(false)
             }
         }
     }
@@ -1297,6 +1429,7 @@ private const val LONG_PRESS_DELAY_MS = 350L
 private const val SEEK_FEEDBACK_VISIBLE_MS = 450L
 private const val NORMAL_PLAYBACK_SPEED = 1f
 private const val FAST_PLAYBACK_SPEED = 2f
+private const val MAX_PLAYBACK_SPEED = 4f
 private const val MEDIA_VIEWER_PRESENTER_KEY = "media_viewer"
 
 @OptIn(ExperimentalTelephotoApi::class)

--- a/app/src/main/java/dev/dimension/flare/ui/screen/settings/AppearanceMediaScreen.kt
+++ b/app/src/main/java/dev/dimension/flare/ui/screen/settings/AppearanceMediaScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SegmentedListItem
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -24,6 +25,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -54,6 +56,7 @@ import dev.dimension.flare.ui.theme.single
 import kotlinx.collections.immutable.persistentMapOf
 import moe.tlaster.precompose.molecule.producePresenter
 import org.koin.compose.koinInject
+import kotlin.math.roundToInt
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -261,6 +264,35 @@ internal fun AppearanceMediaScreen(onBack: () -> Unit) {
                     shapes = ListItemDefaults.item(),
                 )
             }
+            var playbackSpeedValue by remember(globalAppearance.mediaPlaybackSpeed) {
+                mutableFloatStateOf(globalAppearance.mediaPlaybackSpeed)
+            }
+            SegmentedListItem(
+                onClick = {},
+                shapes = ListItemDefaults.item(),
+                content = {
+                    Text(text = stringResource(id = R.string.settings_media_playback_speed))
+                },
+                supportingContent = {
+                    Column {
+                        Text(text = stringResource(id = R.string.settings_media_playback_speed_description))
+                        Slider(
+                            value = playbackSpeedValue,
+                            onValueChange = {
+                                playbackSpeedValue = (it * 10).roundToInt() / 10f
+                            },
+                            onValueChangeFinished = {
+                                state.update(AppearanceKeys.MediaPlaybackSpeed, playbackSpeedValue)
+                            },
+                            valueRange = 1f..4f,
+                            steps = 29,
+                        )
+                    }
+                },
+                trailingContent = {
+                    Text(text = "%.1fx".format(playbackSpeedValue))
+                },
+            )
             val mediaSaveLocationText =
                 when (mediaSaveLocation.mode) {
                     MediaSaveLocationMode.DefaultDownloads -> {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -451,6 +451,10 @@
     <string name="media_menu_share_image">Share image</string>
     <string name="media_menu_copy_link">Copy link</string>
     <string name="media_menu_media_link">Media link</string>
+    <string name="media_menu_open_external">Open in external app</string>
+    <string name="media_playback_speed">Playback speed</string>
+    <string name="settings_media_playback_speed">Default playback speed</string>
+    <string name="settings_media_playback_speed_description">Speed used when playing videos in the media viewer</string>
     <string name="status_menu_share_via_fxembed">Share via FxEmbed</string>
     <string name="status_menu_share_via_fixvx">Share via Fixvx</string>
     <string name="media_save_success">Saved</string>

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/model/appearance/AppearanceKeys.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/model/appearance/AppearanceKeys.kt
@@ -53,6 +53,8 @@ public object AppearanceKeys {
 
     public object DeckMode : Global<Boolean>("app.deck_mode", false, Boolean.serializer())
 
+    public object MediaPlaybackSpeed : Global<Float>("app.media_playback_speed", 1f, Float.serializer())
+
     public object ShowMedia : PerTimeline<Boolean>("timeline.show_media", true, Boolean.serializer())
 
     public object ShowSensitiveContent : PerTimeline<Boolean>("timeline.show_sensitive_content", false, Boolean.serializer())
@@ -132,6 +134,7 @@ public object AppearanceKeys {
             ShowComposeInHomeTimeline,
             ShowBottomBarLabels,
             DeckMode,
+            MediaPlaybackSpeed,
             ShowMedia,
             ShowSensitiveContent,
             ExpandContentWarning,

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/model/appearance/AppearanceModels.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/model/appearance/AppearanceModels.kt
@@ -25,6 +25,7 @@ public data class GlobalAppearance(
     val showComposeInHomeTimeline: Boolean = AppearanceKeys.ShowComposeInHomeTimeline.default,
     val showBottomBarLabels: Boolean = AppearanceKeys.ShowBottomBarLabels.default,
     val deckMode: Boolean = AppearanceKeys.DeckMode.default,
+    val mediaPlaybackSpeed: Float = AppearanceKeys.MediaPlaybackSpeed.default,
 ) {
     public companion object {
         public val Default: GlobalAppearance = GlobalAppearance()
@@ -82,6 +83,7 @@ public fun AppearancePatch.toGlobalAppearance(): GlobalAppearance =
         showComposeInHomeTimeline = get(AppearanceKeys.ShowComposeInHomeTimeline),
         showBottomBarLabels = get(AppearanceKeys.ShowBottomBarLabels),
         deckMode = get(AppearanceKeys.DeckMode),
+        mediaPlaybackSpeed = get(AppearanceKeys.MediaPlaybackSpeed),
     )
 
 public fun AppearancePatch.toTimelineAppearance(): TimelineAppearance = toTimelineAppearance(override = null)


### PR DESCRIPTION
## Summary

- **User-selectable playback speed**: Videos in the media viewer now have a speed button in the player controls that reveals a slider allowing playback speeds from 1x to 4x in 0.1x increments, applied directly to the shared ExoPlayer.
- **Default playback speed setting**: New `app.media_playback_speed` global appearance key (persisted and included in settings export/import) with a slider in Settings > Appearance > Media. The media viewer starts each video at this speed and resets to it when swiping between pages.
- **Open in external app**: Any selected media item (image, video, GIF, audio) can be opened in an external app via a new top-bar button and a long-press sheet entry, using an `ACTION_VIEW` chooser with the appropriate MIME type.

## Details

- The existing long-press fast-playback gesture now restores the user-selected speed on release instead of always snapping back to 1x, and fast-plays at `max(2x, selected speed)`.
- The fast-playback badge and auto-shown bottom UI now key off actual fast-playback state rather than `speed > 1x`, so a custom default speed does not pin the UI open.
- Android-only; shared module changes are limited to the new appearance key and `GlobalAppearance` field with a default value, so other platforms are unaffected.

## Testing

- Built `:app:assembleDebug` and verified on a physical device (speed selection, default speed applied on open and page change, fast-playback gesture restore, open-in-external-app for images and videos).