### PR TITLE
fix(mastodon): preserve paging type under R8

### DIFF
--- a/social/mastodon/src/commonMain/kotlin/dev/dimension/flare/data/network/mastodon/api/model/MastodonPaging.kt
+++ b/social/mastodon/src/commonMain/kotlin/dev/dimension/flare/data/network/mastodon/api/model/MastodonPaging.kt
@@ -9,8 +9,11 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.util.reflect.serializer
 import io.ktor.utils.io.InternalAPI
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 
+// Ktorfit reads T at runtime; serialization's consumer rule retains its signature under R8.
+@Serializable
 internal class MastodonPaging<T>(
     private val data: List<T>,
     val next: String? = null,


### PR DESCRIPTION
## Summary

- Mark `MastodonPaging<T>` with `@Serializable`.
- Reuse kotlinx serialization's consumer keep rule to retain the model's generic `Signature` in R8 full mode.

## Root cause

Ktorfit reads the response element type from `MastodonPaging<T>` at runtime. R8 removed that generic signature, leaving `TypeData.typeArgs` empty and causing `NoSuchElementException: List is empty` in the Mastodon converter.

## Verification

- `./gradlew :social:mastodon:jvmTest --console=plain`
- `./gradlew :app:assembleRelease --console=plain`
- Inspected the release DEX and confirmed `MastodonPaging<T>` retains `dalvik.annotation.Signature`.
- Installed the release APK on the emulator and confirmed the Mastodon timeline loads without the previous error.
