### PR TITLE
fix(timeline): prevent duplicate threads in chronological mixed feeds

### DIFF
--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/dao/PagingTimelineDao.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/database/cache/dao/PagingTimelineDao.kt
@@ -397,6 +397,16 @@ internal interface PagingTimelineDao {
     )
     suspend fun getByPagingKey(pagingKey: String): List<DbPagingTimeline>
 
+    @Query(
+        "SELECT statusId FROM DbPagingTimeline WHERE pagingKey = :pagingKey " +
+            "UNION " +
+            "SELECT presentation.referenceStatusId FROM timeline_item_presentation_reference AS presentation " +
+            "INNER JOIN DbPagingTimeline AS timeline " +
+            "ON timeline.pagingKey = presentation.pagingKey AND timeline.statusId = presentation.statusId " +
+            "WHERE timeline.pagingKey = :pagingKey AND presentation.presentationType = 'InlineParent'",
+    )
+    suspend fun getStatusIdsWithInlineParents(pagingKey: String): List<String>
+
     @Query("SELECT MIN(sortId) FROM DbPagingTimeline WHERE pagingKey = :pagingKey")
     suspend fun getMinSortId(pagingKey: String): Long?
 

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/datasource/microblog/MixedRemoteMediator.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/datasource/microblog/MixedRemoteMediator.kt
@@ -109,10 +109,11 @@ internal class MixedRemoteMediator(
 
             val seenStatusIds =
                 if (request is PagingRequest.Append) {
+                    // Collapsed parents have already been displayed, even without their own timeline row.
                     database
                         .pagingTimelineDao()
-                        .getByPagingKey(pagingKey)
-                        .mapTo(mutableSetOf()) { it.statusId }
+                        .getStatusIdsWithInlineParents(pagingKey)
+                        .toMutableSet()
                 } else {
                     mutableSetOf()
                 }

--- a/shared/src/commonTest/kotlin/dev/dimension/flare/data/database/cache/dao/PagingTimelineDaoTest.kt
+++ b/shared/src/commonTest/kotlin/dev/dimension/flare/data/database/cache/dao/PagingTimelineDaoTest.kt
@@ -1,0 +1,80 @@
+package dev.dimension.flare.data.database.cache.dao
+
+import androidx.room3.Room
+import dev.dimension.flare.RobolectricTest
+import dev.dimension.flare.data.database.cache.CacheDatabase
+import dev.dimension.flare.data.database.cache.model.DbPagingTimeline
+import dev.dimension.flare.data.database.cache.model.DbTimelineItemPresentationReference
+import dev.dimension.flare.data.database.cache.model.DbTimelineItemPresentationType
+import dev.dimension.flare.data.database.createDatabaseDriver
+import dev.dimension.flare.memoryDatabaseBuilder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PagingTimelineDaoTest : RobolectricTest() {
+    private lateinit var db: CacheDatabase
+
+    @BeforeTest
+    fun setup() {
+        db =
+            Room
+                .memoryDatabaseBuilder<CacheDatabase>()
+                .setDriver(createDatabaseDriver())
+                .setQueryCoroutineContext(Dispatchers.Unconfined)
+                .build()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun statusIdsWithInlineParentsIncludeOnlyCurrentTimelineRootsAndParents() =
+        runTest {
+            val dao = db.pagingTimelineDao()
+            dao.insertAll(
+                listOf(
+                    DbPagingTimeline(pagingKey = "mixed", statusId = "leaf", sortId = 0),
+                    DbPagingTimeline(pagingKey = "mixed", statusId = "parent", sortId = 1),
+                    DbPagingTimeline(pagingKey = "other", statusId = "leaf", sortId = 0),
+                ),
+            )
+            val parentReference =
+                DbTimelineItemPresentationReference(
+                    pagingKey = "mixed",
+                    statusId = "leaf",
+                    referenceStatusId = "parent",
+                    presentationType = DbTimelineItemPresentationType.InlineParent,
+                )
+            dao.insertPresentationReferences(
+                listOf(
+                    parentReference,
+                    parentReference.copy(referenceStatusId = "ancestor"),
+                    parentReference.copy(
+                        referenceStatusId = "quote",
+                        presentationType = DbTimelineItemPresentationType.Quote,
+                    ),
+                    parentReference.copy(
+                        referenceStatusId = "repost",
+                        presentationType = DbTimelineItemPresentationType.Repost,
+                    ),
+                    parentReference.copy(pagingKey = "other", referenceStatusId = "other-parent"),
+                    parentReference.copy(statusId = "deleted-root", referenceStatusId = "orphaned-parent"),
+                ),
+            )
+
+            assertEquals(
+                listOf("ancestor", "leaf", "parent"),
+                dao.getStatusIdsWithInlineParents("mixed").sorted(),
+            )
+            assertEquals(
+                listOf("leaf", "other-parent"),
+                dao.getStatusIdsWithInlineParents("other").sorted(),
+            )
+        }
+}

--- a/shared/src/commonTest/kotlin/dev/dimension/flare/data/datasource/microblog/MixedRemoteMediatorTest.kt
+++ b/shared/src/commonTest/kotlin/dev/dimension/flare/data/datasource/microblog/MixedRemoteMediatorTest.kt
@@ -2,9 +2,11 @@ package dev.dimension.flare.data.datasource.microblog
 
 import androidx.paging.ExperimentalPagingApi
 import androidx.paging.LoadType
+import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
+import androidx.paging.testing.asSnapshot
 import androidx.room3.Room
 import dev.dimension.flare.RobolectricTest
 import dev.dimension.flare.common.Locale
@@ -25,6 +27,7 @@ import dev.dimension.flare.data.database.cache.model.TranslationStatus
 import dev.dimension.flare.data.database.createDatabaseDriver
 import dev.dimension.flare.data.datasource.microblog.paging.CacheableRemoteLoader
 import dev.dimension.flare.data.datasource.microblog.paging.OffsetFromStartPagingKey
+import dev.dimension.flare.data.datasource.microblog.paging.OffsetFromStartPagingSource
 import dev.dimension.flare.data.datasource.microblog.paging.PagingRequest
 import dev.dimension.flare.data.datasource.microblog.paging.PagingResult
 import dev.dimension.flare.data.datasource.microblog.paging.SortIdProvider
@@ -675,6 +678,106 @@ class MixedRemoteMediatorTest : RobolectricTest() {
                 },
             )
         }
+
+    @Test
+    fun timeMergePolicyDoesNotReplayTwoPostThreadOnInitialLoad() =
+        runTest {
+            assertThreadIsNotReplayedOnInitialLoad(threadSize = 2)
+        }
+
+    @Test
+    fun timeMergePolicyDoesNotReplayNinePostThreadOnInitialLoad() =
+        runTest {
+            assertThreadIsNotReplayedOnInitialLoad(threadSize = 9)
+        }
+
+    @OptIn(ExperimentalPagingApi::class)
+    private suspend fun assertThreadIsNotReplayedOnInitialLoad(threadSize: Int) {
+        val blueskyAccount = AccountType.Specific(MicroBlogKey("viewer", "bsky.social"))
+        val blueskyAuthor = profile(MicroBlogKey("author", "bsky.social"), "Thread author")
+        val mastodonAccount = AccountType.Specific(MicroBlogKey("viewer", "mastodon.example"))
+        val mastodonAuthor = profile(MicroBlogKey("author", "mastodon.example"), "Other author")
+        val thread =
+            (1..threadSize).map { index ->
+                createPost(
+                    accountType = blueskyAccount,
+                    user = blueskyAuthor,
+                    statusKey = MicroBlogKey("thread_$index", "bsky.social"),
+                    text = "$index/$threadSize",
+                ).copy(
+                    platformId = "Bluesky",
+                    createdAt = Instant.fromEpochMilliseconds(10_000L + index).toUi(),
+                )
+            }
+        val threadItems =
+            thread.mapIndexed { index, post ->
+                UiTimelineV2.TimelinePostItem(
+                    post = post,
+                    presentation =
+                        UiTimelineV2.PostPresentation(
+                            inlineParents = listOfNotNull(thread.getOrNull(index - 1)).toPersistentList(),
+                        ),
+                )
+            }
+        val otherBlueskyPosts =
+            (1..(20 - threadSize)).map { index ->
+                createPost(
+                    accountType = blueskyAccount,
+                    user = blueskyAuthor,
+                    statusKey = MicroBlogKey("other_$index", "bsky.social"),
+                    text = "Other Bluesky post $index",
+                ).copy(createdAt = Instant.fromEpochMilliseconds(2_000L + index).toUi())
+            }
+        val mastodonPosts =
+            (1..20).map { index ->
+                createPost(
+                    accountType = mastodonAccount,
+                    user = mastodonAuthor,
+                    statusKey = MicroBlogKey("other_$index", "mastodon.example"),
+                    text = "Mastodon post $index",
+                ).copy(createdAt = Instant.fromEpochMilliseconds(1_000L + index).toUi())
+            }
+        val bluesky =
+            FakeLoader("bluesky_home") { request ->
+                assertEquals(PagingRequest.Refresh, request)
+                PagingResult(data = threadItems.reversed() + otherBlueskyPosts)
+            }
+        val mastodon =
+            FakeLoader("mastodon_home") { request ->
+                assertEquals(PagingRequest.Refresh, request)
+                PagingResult(data = mastodonPosts)
+            }
+        val mixed = MixedRemoteMediator(db, listOf(bluesky, mastodon), TimelineMergePolicy.Time)
+        val pageCache = TimelineDbPageCache()
+        val snapshot =
+            Pager(
+                config = offsetPagingConfig,
+                remoteMediator = TimelineRemoteMediator(mixed, db, allowLongText = false),
+                pagingSourceFactory = {
+                    OffsetFromStartPagingSource(TimelineDbPageLoader(db, mixed.pagingKey, pageCache))
+                },
+            ).flow.asSnapshot()
+
+        val threadKeys = thread.map { it.statusKey }
+        val displayedThread =
+            snapshot.flatMap { item ->
+                val post = assertIs<UiTimelineV2.TimelinePostItem>(item.baseItem)
+                (post.presentation.inlineParents + post.displayPost)
+                    .map { it.statusKey }
+                    .filter { it in threadKeys }
+            }
+        assertEquals(threadKeys, displayedThread)
+        assertEquals(listOf<PagingRequest>(PagingRequest.Refresh), bluesky.requests)
+        assertEquals(listOf<PagingRequest>(PagingRequest.Refresh), mastodon.requests)
+        assertEquals(
+            (listOf(thread.last()) + otherBlueskyPosts + mastodonPosts).map { it.statusKey }.toSet(),
+            db
+                .pagingTimelineDao()
+                .getTimelinePage(mixed.pagingKey, offset = 0, limit = 40)
+                .map { it.statusData.statusKey }
+                .toSet(),
+        )
+    }
 
     @OptIn(ExperimentalPagingApi::class)
     @Test


### PR DESCRIPTION
Chronological mixed timelines could repeat a thread during the initial load: `[1…9]` was followed by `[1…8]`, even when Bluesky and Mastodon each returned only one remote page. Collapsed parents remained in staging because only the final timeline root rows were counted as consumed.

Include inline-parent IDs in the consumed set before reading staged items again. The SQL query returns only IDs and scopes references to existing roots in the current timeline.

Validation:
- 35 JVM tests passed: `./gradlew :shared:jvmTest --tests '*MixedRemoteMediatorTest' --tests '*PagingTimelineDaoTest'`.
- Added two-post and nine-post initial-load regressions; both failed before the fix and pass afterward.
- Added DAO coverage for reference types, timeline isolation, duplicate IDs, and references left behind by deleted roots.
- Ran ktlint format/check on all four changed Kotlin files and `git diff --check`.

Fixes #2166.