### PR TITLE
fix(ios): respect media viewer safe area

### DIFF
--- a/appleApp/ios/UI/Screen/MediaViewerScreen.swift
+++ b/appleApp/ios/UI/Screen/MediaViewerScreen.swift
@@ -301,7 +301,7 @@ struct MediaViewerScreen<SupplementaryOverlay: View>: View {
         }
         .buttonStyle(.plain)
         .foregroundStyle(.white)
-        .padding(.horizontal)
+        .safeAreaPadding([.top, .horizontal])
     }
 
     private func topOverlayButton<Label: View>(


### PR DESCRIPTION
The full-screen iOS media viewer placed its top controls directly against the screen edge in landscape, where the system's top safe-area inset is zero. Use `safeAreaPadding([.top, .horizontal])` for the controls so SwiftUI adds platform-default spacing relative to the current safe area while media stays full-screen.

Validated with Swift parsing and `git diff --check`, plus an isolated SwiftUI/LazyPager simulator harness on iPhone 15 Pro (iOS 18.6 and 27) and iPad mini (iOS 27), covering portrait/landscape rotation, hiding/restoring controls, and full-screen media bounds.