### PR TITLE
fix: honor repost layout for standalone quotes

### DIFF
--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/datasource/microblog/ActionMenu.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/datasource/microblog/ActionMenu.kt
@@ -191,7 +191,12 @@ public fun ImmutableList<ActionMenu>.applyPostActionLayout(config: PostActionLay
         when (action) {
             is ActionMenu.Item -> {
                 if (!action.isDisplayOnlyPostActionContainer()) {
-                    entries += PostActionEntry(nextIndex++, action, action.actionFamily)
+                    val family =
+                        when (action.actionFamily) {
+                            PostActionFamily.Quote -> PostActionFamily.Repost
+                            else -> action.actionFamily
+                        }
+                    entries += PostActionEntry(nextIndex++, action, family)
                 }
             }
 

--- a/shared/src/commonTest/kotlin/dev/dimension/flare/data/datasource/microblog/PostActionLayoutConfigTest.kt
+++ b/shared/src/commonTest/kotlin/dev/dimension/flare/data/datasource/microblog/PostActionLayoutConfigTest.kt
@@ -109,6 +109,54 @@ class PostActionLayoutConfigTest {
         assertFalse(result.any { it is ActionMenu.Group })
     }
 
+    @Test
+    fun standaloneQuoteUsesRepostPositionWithoutCreatingMoreMenu() {
+        val quote = action(PostActionFamily.Quote, UiIcon.Quote)
+        val like = action(PostActionFamily.Like, UiIcon.Like)
+        val actions = persistentListOf<ActionMenu>(quote, like)
+        val config =
+            PostActionLayoutConfig(
+                enabled = true,
+                primary = persistentListOf(PostActionFamily.Like, PostActionFamily.Repost),
+                overflow = persistentListOf(),
+            )
+
+        assertEquals(listOf<ActionMenu>(like, quote), actions.applyPostActionLayout(config))
+    }
+
+    @Test
+    fun standaloneQuoteUsesRepostPositionInMoreMenu() {
+        val quote = action(PostActionFamily.Quote, UiIcon.Quote)
+        val share = action(PostActionFamily.Share, UiIcon.Share)
+        val actions = persistentListOf<ActionMenu>(quote, share)
+        val config =
+            PostActionLayoutConfig(
+                enabled = true,
+                primary = persistentListOf(),
+                overflow = persistentListOf(PostActionFamily.Repost, PostActionFamily.Share),
+            )
+
+        val more = assertIs<ActionMenu.Group>(actions.applyPostActionLayout(config).single())
+        assertEquals(moreItem(), more.displayItem)
+        assertEquals(listOf<ActionMenu>(quote, share), more.actions)
+    }
+
+    @Test
+    fun hidingRepostHidesStandaloneQuote() {
+        val quote = action(PostActionFamily.Quote, UiIcon.Quote)
+        val like = action(PostActionFamily.Like, UiIcon.Like)
+        val actions = persistentListOf<ActionMenu>(quote, like)
+        val config =
+            PostActionLayoutConfig(
+                enabled = true,
+                primary = persistentListOf(PostActionFamily.Like),
+                overflow = persistentListOf(),
+                hidden = persistentListOf(PostActionFamily.Repost),
+            )
+
+        assertEquals(listOf<ActionMenu>(like), actions.applyPostActionLayout(config))
+    }
+
     private fun action(
         family: PostActionFamily,
         icon: UiIcon,

--- a/social/vvo/src/commonTest/kotlin/dev/dimension/flare/ui/model/mapper/VVORenderTest.kt
+++ b/social/vvo/src/commonTest/kotlin/dev/dimension/flare/ui/model/mapper/VVORenderTest.kt
@@ -2,6 +2,12 @@ package dev.dimension.flare.ui.model.mapper
 
 import dev.dimension.flare.common.JSON
 import dev.dimension.flare.common.TestFormatter
+import dev.dimension.flare.data.datasource.microblog.ActionMenu
+import dev.dimension.flare.data.datasource.microblog.PostActionFamily
+import dev.dimension.flare.data.datasource.microblog.PostActionLayoutConfig
+import dev.dimension.flare.data.datasource.microblog.PostActionLayoutHelpers
+import dev.dimension.flare.data.datasource.microblog.PostActionPlacement
+import dev.dimension.flare.data.datasource.microblog.applyPostActionLayout
 import dev.dimension.flare.data.network.vvo.model.Large
 import dev.dimension.flare.data.network.vvo.model.Status
 import dev.dimension.flare.data.network.vvo.model.StatusPic
@@ -23,6 +29,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 import kotlin.time.Instant
 
 class VVORenderTest {
@@ -119,6 +126,37 @@ class VVORenderTest {
             rendered.presentation.quotes
                 .first()
                 .content.original.innerText,
+        )
+    }
+
+    @Test
+    fun quoteFollowsRepostLayoutAfterClearingMoreMenu() {
+        val status =
+            createStatus(
+                id = "status-actions",
+                user = createUser(1L, "actions-user"),
+                text = "post with quote action",
+            )
+        val post = assertIs<UiTimelineV2.Post>(status.render(accountKey))
+        val quote = post.actions.filterIsInstance<ActionMenu.Item>().single { it.actionFamily == PostActionFamily.Quote }
+        var config = PostActionLayoutHelpers.withEnabled(PostActionLayoutConfig.Default, true)
+        for (family in config.overflow.toList()) {
+            config = PostActionLayoutHelpers.moveTo(config, family, PostActionPlacement.Hidden)
+        }
+        assertTrue(config.overflow.isEmpty())
+
+        val actions = post.actions.applyPostActionLayout(config)
+
+        assertEquals(
+            listOf(PostActionFamily.Comment, PostActionFamily.Quote, PostActionFamily.Like),
+            actions.map { assertIs<ActionMenu.Item>(it).actionFamily },
+        )
+        assertEquals(quote, actions[1])
+
+        val hiddenConfig = PostActionLayoutHelpers.moveTo(config, PostActionFamily.Repost, PostActionPlacement.Hidden)
+        assertEquals(
+            actions.filterNot { it == quote },
+            post.actions.applyPostActionLayout(hiddenConfig),
         )
     }
 


### PR DESCRIPTION
Customizing post actions could leave a More → Quote menu on Weibo posts even after every More menu action had been moved or hidden. Standalone quotes used the Quote action family, which is absent from the editable layout settings, so the layout resolver added them back to More.

Classify standalone quotes as Repost when resolving the layout. They now follow the repost position, order, and visibility settings while retaining the quote icon and click action.

Validation:

- Added regression coverage for button-row placement, More menu ordering, hiding reposts, and the original Weibo rendering scenario.
- All 9 tests in PostActionLayoutConfigTest and VVORenderTest pass; the 4 new regression tests fail on the previous implementation.
- ktlint passes for all changed Kotlin files.
