### PR TITLE
fix: keep unavailable post actions visible in custom layouts

### DIFF
--- a/appleApp/Shared/FlareAppleCore/Sources/FlareAppleUI/TimelineItem/StatusActionView.swift
+++ b/appleApp/Shared/FlareAppleCore/Sources/FlareAppleUI/TimelineItem/StatusActionView.swift
@@ -253,7 +253,9 @@ public struct StatusActionItemView: View {
             .accessibilityValue(
                 Text(verbatim: showNumbers ? (data.count?.humanized ?? "") : "")
             )
-            .macOSStatusActionHoverStyle(isEnabled: !useText)
+            .disabled(!data.enabled)
+            .opacity(data.enabled ? 1 : 0.4)
+            .macOSStatusActionHoverStyle(isEnabled: !useText && data.enabled)
             .statusActionFixedWidthSlot(
                 icon: data.icon,
                 fontSize: fontSize,

--- a/appleApp/ios/UI/Component/Status/StatusUIKitActions.swift
+++ b/appleApp/ios/UI/Component/Status/StatusUIKitActions.swift
@@ -299,6 +299,7 @@ final class StatusActionsUIView: UIView, ManualLayoutMeasurable, TimelineHeightP
         }
         let control = itemButtonPool[itemButtonCursor]
         itemButtonCursor += 1
+        control.isEnabled = item.enabled
         control.configure(
             image: item.icon.flatMap { UIImage(fontAwesome: $0.fontAwesomeIcon) },
             title: title,
@@ -332,6 +333,7 @@ final class StatusActionsUIView: UIView, ManualLayoutMeasurable, TimelineHeightP
         }
         let control = groupButtonPool[groupButtonCursor]
         groupButtonCursor += 1
+        control.isEnabled = group.displayItem.enabled
         control.configure(
             image: group.displayItem.icon.flatMap { UIImage(fontAwesome: $0.fontAwesomeIcon) },
             title: title,
@@ -395,10 +397,14 @@ final class StatusActionsUIView: UIView, ManualLayoutMeasurable, TimelineHeightP
                     title = ""
                 }
                 let image = item.icon.flatMap { UIImage(fontAwesome: $0.fontAwesomeIcon) }
+                var attributes: UIMenuElement.Attributes = item.color == .red ? .destructive : []
+                if !item.enabled {
+                    attributes.insert(.disabled)
+                }
                 let uiAction = UIAction(
                     title: title,
                     image: image,
-                    attributes: item.color == .red ? .destructive : []
+                    attributes: attributes
                 ) { [weak self] _ in
                     guard let self = self else { return }
                     let gen = UIImpactFeedbackGenerator(style: .medium)
@@ -722,7 +728,11 @@ private final class ActionItemControl: UIButton, ManualLayoutMeasurable, Timelin
     }
 
     override var isHighlighted: Bool {
-        didSet { alpha = isHighlighted ? 0.55 : 1 }
+        didSet { alpha = isEnabled ? (isHighlighted ? 0.55 : 1) : 0.4 }
+    }
+
+    override var isEnabled: Bool {
+        didSet { alpha = isEnabled ? 1 : 0.4 }
     }
 }
 

--- a/appleApp/ios/UI/Screen/ProfileScreen.swift
+++ b/appleApp/ios/UI/Screen/ProfileScreen.swift
@@ -91,7 +91,12 @@ struct ProfileScreen: View {
                         .accessibilityLabel(Text(String(localized: "profile_insight_title", defaultValue: "Profile insight")))
                     }
                     if !presenter.state.actions.isEmpty {
-                        StatusActionsView(data: presenter.state.actions, useText: false, allowSpacer: false)
+                        StatusActionsView(
+                            data: presenter.state.actions,
+                            useText: false,
+                            allowSpacer: false,
+                            applyPostActionLayout: false
+                        )
                     }
                 }
             }

--- a/appleApp/macos/UI/Screen/ProfileScreen.swift
+++ b/appleApp/macos/UI/Screen/ProfileScreen.swift
@@ -97,7 +97,8 @@ struct ProfileScreen: View {
                     StatusActionsView(
                         data: presenter.state.actions,
                         useText: false,
-                        allowSpacer: false
+                        allowSpacer: false,
+                        applyPostActionLayout: false
                     )
                     .buttonStyle(.plain)
                 }

--- a/compose-ui/src/androidMain/kotlin/dev/dimension/flare/ui/component/platform/PlatformDropdown.android.kt
+++ b/compose-ui/src/androidMain/kotlin/dev/dimension/flare/ui/component/platform/PlatformDropdown.android.kt
@@ -29,6 +29,7 @@ internal actual fun PlatformDropdownMenuScope.PlatformDropdownMenuItem(
     modifier: Modifier,
     leadingIcon: @Composable (() -> Unit)?,
     trailingIcon: @Composable (() -> Unit)?,
+    enabled: Boolean,
 ) {
     DropdownMenuItem(
         text = text,
@@ -36,6 +37,7 @@ internal actual fun PlatformDropdownMenuScope.PlatformDropdownMenuItem(
         modifier = modifier,
         leadingIcon = leadingIcon,
         trailingIcon = trailingIcon,
+        enabled = enabled,
     )
 }
 

--- a/compose-ui/src/commonMain/kotlin/dev/dimension/flare/ui/component/platform/PlatformDropdown.kt
+++ b/compose-ui/src/commonMain/kotlin/dev/dimension/flare/ui/component/platform/PlatformDropdown.kt
@@ -20,6 +20,7 @@ internal expect fun PlatformDropdownMenuScope.PlatformDropdownMenuItem(
     modifier: Modifier = Modifier,
     leadingIcon: @Composable (() -> Unit)? = null,
     trailingIcon: @Composable (() -> Unit)? = null,
+    enabled: Boolean = true,
 )
 
 @Composable

--- a/compose-ui/src/commonMain/kotlin/dev/dimension/flare/ui/component/status/CommonStatusComponent.kt
+++ b/compose-ui/src/commonMain/kotlin/dev/dimension/flare/ui/component/status/CommonStatusComponent.kt
@@ -1050,6 +1050,7 @@ internal fun StatusActions(
                         contentDescription =
                             action.text?.asString()
                                 ?: stringResource(Res.string.more),
+                        enabled = action.enabled,
                         withTextMinWidth =
                             appearanceSettings.postActionFixedWidth &&
                                 action.count != null &&
@@ -1173,6 +1174,7 @@ private fun PlatformDropdownMenuScope.StatusActionItemMenu(
 ) {
     val color = subActions.color?.toComposeColor() ?: PlatformContentColor.current
     PlatformDropdownMenuItem(
+        enabled = subActions.enabled,
         leadingIcon = {
             subActions.icon?.let {
                 FAIcon(

--- a/compose-ui/src/commonMain/kotlin/dev/dimension/flare/ui/component/status/StatusActionButton.kt
+++ b/compose-ui/src/commonMain/kotlin/dev/dimension/flare/ui/component/status/StatusActionButton.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.PointerIcon
@@ -120,7 +121,7 @@ public fun StatusActionButton(
                     modifier =
                         Modifier
                             .height(PlatformTextStyle.current.fontSize.value.dp + 2.dp)
-                            .pointerHoverIcon(PointerIcon.Hand)
+                            .pointerHoverIcon(if (enabled) PointerIcon.Hand else PointerIcon.Default)
                             .clickable(
                                 onClick = onClicked,
                                 enabled = enabled,
@@ -142,7 +143,7 @@ public fun StatusActionButton(
                 modifier =
                     Modifier
                         .height(PlatformTextStyle.current.fontSize.value.dp + 2.dp)
-                        .pointerHoverIcon(PointerIcon.Hand)
+                        .pointerHoverIcon(if (enabled) PointerIcon.Hand else PointerIcon.Default)
                         .clickable(
                             onClick = onClicked,
                             enabled = enabled,
@@ -162,6 +163,7 @@ public fun StatusActionButton(
         modifier =
             modifier
                 .then(accessibilityModifier)
+                .alpha(if (enabled) 1f else 0.4f)
                 .padding(vertical = 4.dp, horizontal = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(2.dp),
@@ -204,7 +206,7 @@ public fun StatusActionButton(
                     color = color,
                     modifier =
                         Modifier
-                            .pointerHoverIcon(PointerIcon.Hand)
+                            .pointerHoverIcon(if (enabled) PointerIcon.Hand else PointerIcon.Default)
                             .clickable(
                                 onClick = onClicked,
                                 enabled = enabled,

--- a/compose-ui/src/jvmMain/kotlin/dev/dimension/flare/ui/component/platform/PlatformDropdown.jvm.kt
+++ b/compose-ui/src/jvmMain/kotlin/dev/dimension/flare/ui/component/platform/PlatformDropdown.jvm.kt
@@ -31,6 +31,7 @@ internal actual fun PlatformDropdownMenuScope.PlatformDropdownMenuItem(
     modifier: Modifier,
     leadingIcon: @Composable (() -> Unit)?,
     trailingIcon: @Composable (() -> Unit)?,
+    enabled: Boolean,
 ) {
     MenuFlyoutItem(
         onClick = onClick,
@@ -38,6 +39,7 @@ internal actual fun PlatformDropdownMenuScope.PlatformDropdownMenuItem(
         icon = leadingIcon,
         trailing = trailingIcon,
         modifier = modifier,
+        enabled = enabled,
     )
 }
 

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/data/datasource/microblog/ActionMenu.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/data/datasource/microblog/ActionMenu.kt
@@ -107,6 +107,7 @@ public sealed class ActionMenu {
         val color: Color? = null,
         public val clickEvent: ClickEvent = ClickEvent.Noop,
         val actionFamily: PostActionFamily? = null,
+        val enabled: Boolean = true,
     ) : ActionMenu() {
         init {
             require(icon != null || text != null) {
@@ -234,7 +235,7 @@ public fun ImmutableList<ActionMenu>.applyPostActionLayout(config: PostActionLay
             .filterNot { it in hiddenFamilies }
             .filterNot { it in primaryFamilies }
 
-    val primaryActions = primaryFamilies.mapNotNull(::pick).toMutableList<ActionMenu>()
+    val primaryActions = primaryFamilies.map { family -> pick(family) ?: family.disabledAction() }
     val overflowActions = overflowFamilies.mapNotNull(::pick).toMutableList<ActionMenu>()
     overflowActions +=
         entries
@@ -449,6 +450,33 @@ private data class PostActionEntry(
     val action: ActionMenu,
     val family: PostActionFamily?,
 )
+
+private fun PostActionFamily.disabledAction(): ActionMenu.Item {
+    val (icon, text) =
+        when (this) {
+            PostActionFamily.Reply -> UiIcon.Reply to ActionMenu.Item.Text.Localized.Type.Reply
+            PostActionFamily.Comment -> UiIcon.Comment to ActionMenu.Item.Text.Localized.Type.Comment
+            PostActionFamily.Repost -> UiIcon.Retweet to ActionMenu.Item.Text.Localized.Type.Retweet
+            PostActionFamily.Quote -> UiIcon.Quote to ActionMenu.Item.Text.Localized.Type.Quote
+            PostActionFamily.Like -> UiIcon.Like to ActionMenu.Item.Text.Localized.Type.Like
+            PostActionFamily.React -> UiIcon.React to ActionMenu.Item.Text.Localized.Type.React
+            PostActionFamily.Translate -> UiIcon.Translate to ActionMenu.Item.Text.Localized.Type.Translate
+            PostActionFamily.Bookmark -> UiIcon.Bookmark to ActionMenu.Item.Text.Localized.Type.Bookmark
+            PostActionFamily.Favorite -> UiIcon.Favourite to ActionMenu.Item.Text.Localized.Type.Favorite
+            PostActionFamily.Share -> UiIcon.Share to ActionMenu.Item.Text.Localized.Type.Share
+            PostActionFamily.FxShare -> UiIcon.Share to ActionMenu.Item.Text.Localized.Type.FxShare
+            PostActionFamily.Delete -> UiIcon.Delete to ActionMenu.Item.Text.Localized.Type.Delete
+            PostActionFamily.Report -> UiIcon.Report to ActionMenu.Item.Text.Localized.Type.Report
+            PostActionFamily.MuteUser -> UiIcon.Mute to ActionMenu.Item.Text.Localized.Type.Mute
+            PostActionFamily.BlockUser -> UiIcon.Block to ActionMenu.Item.Text.Localized.Type.Block
+        }
+    return ActionMenu.Item(
+        icon = icon,
+        text = ActionMenu.Item.Text.Localized(text),
+        actionFamily = this,
+        enabled = false,
+    )
+}
 
 private fun Iterable<PostActionFamily>.cleanFamilies(): List<PostActionFamily> =
     filter { it in PostActionLayoutHelpers.allEditableFamilies }.distinct()

--- a/shared/src/commonMain/kotlin/dev/dimension/flare/ui/model/UiTimelineV2.kt
+++ b/shared/src/commonMain/kotlin/dev/dimension/flare/ui/model/UiTimelineV2.kt
@@ -672,6 +672,7 @@ private fun ActionMenu.Item.renderSummaryHash(): Int =
         .add(text.renderSummaryHash())
         .add(count)
         .add(color)
+        .add(enabled)
         .build()
 
 private fun ActionMenu.Item.Text?.renderSummaryHash(): Int =

--- a/shared/src/commonTest/kotlin/dev/dimension/flare/data/database/cache/model/TranslationDisplayTest.kt
+++ b/shared/src/commonTest/kotlin/dev/dimension/flare/data/database/cache/model/TranslationDisplayTest.kt
@@ -1,16 +1,80 @@
 package dev.dimension.flare.data.database.cache.model
 
 import dev.dimension.flare.common.Locale
+import dev.dimension.flare.data.datasource.microblog.ActionMenu
+import dev.dimension.flare.data.datasource.microblog.PostActionFamily
+import dev.dimension.flare.data.datasource.microblog.PostActionLayoutConfig
+import dev.dimension.flare.data.datasource.microblog.applyPostActionLayout
+import dev.dimension.flare.data.translation.PreTranslationStoreSupport
+import dev.dimension.flare.ui.model.ClickEvent
 import dev.dimension.flare.ui.model.TranslationDisplayState
+import dev.dimension.flare.ui.model.UiIcon
+import dev.dimension.flare.ui.model.UiTimelineV2
 import dev.dimension.flare.ui.model.UiTranslatableText
 import dev.dimension.flare.ui.model.createSampleStatus
 import dev.dimension.flare.ui.model.createSampleUser
 import dev.dimension.flare.ui.render.toUiPlainText
+import kotlinx.collections.immutable.persistentListOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNull
 
 class TranslationDisplayTest {
+    @Test
+    fun skippedEmptyPostKeepsTranslateSlotInButtonRow() {
+        val post =
+            createSampleStatus(createSampleUser()).copy(
+                content = UiTranslatableText("".toUiPlainText()),
+                actions =
+                    persistentListOf(
+                        ActionMenu.Group(
+                            displayItem =
+                                ActionMenu.Item(
+                                    icon = UiIcon.More,
+                                    text = ActionMenu.Item.Text.Localized(ActionMenu.Item.Text.Localized.Type.More),
+                                ),
+                            actions = persistentListOf(ActionMenu.Item(icon = UiIcon.Share, actionFamily = PostActionFamily.Share)),
+                        ),
+                    ),
+            )
+        val translation =
+            DbTranslation(
+                entityType = TranslationEntityType.Status,
+                entityKey = "post",
+                targetLanguage = Locale.language,
+                sourceHash = requireNotNull(post.translationPayload()).sourceHash("ai"),
+                status = TranslationStatus.Skipped,
+                statusReason = PreTranslationStoreSupport.SKIPPED_EMPTY_REASON,
+                updatedAt = 1,
+            )
+        val displayed =
+            post.applyTranslation(
+                TranslationDisplayOptions(
+                    translationEnabled = true,
+                    autoDisplayEnabled = true,
+                    providerCacheKey = "ai",
+                ),
+                listOf(translation),
+            ) as UiTimelineV2.Post
+
+        val actions =
+            displayed.actions.applyPostActionLayout(
+                PostActionLayoutConfig(
+                    enabled = true,
+                    primary = persistentListOf(PostActionFamily.Translate),
+                ),
+            )
+
+        val translate = assertIs<ActionMenu.Item>(actions.first())
+        assertEquals(PostActionFamily.Translate, translate.actionFamily)
+        assertEquals(UiIcon.Translate, translate.icon)
+        assertEquals(ClickEvent.Noop, translate.clickEvent)
+        assertFalse(translate.enabled)
+        assertEquals(post.actions, displayed.actions)
+    }
+
     @Test
     fun selectedTranslationPopulatesWrapperWithoutChangingOriginal() {
         val post =

--- a/shared/src/commonTest/kotlin/dev/dimension/flare/data/datasource/microblog/PostActionLayoutConfigTest.kt
+++ b/shared/src/commonTest/kotlin/dev/dimension/flare/data/datasource/microblog/PostActionLayoutConfigTest.kt
@@ -1,11 +1,15 @@
 package dev.dimension.flare.data.datasource.microblog
 
+import dev.dimension.flare.ui.model.ClickEvent
 import dev.dimension.flare.ui.model.UiIcon
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class PostActionLayoutConfigTest {
     @Test
@@ -155,6 +159,104 @@ class PostActionLayoutConfigTest {
             )
 
         assertEquals(listOf<ActionMenu>(like), actions.applyPostActionLayout(config))
+    }
+
+    @Test
+    fun unavailableActionsKeepTheirConfiguredPositions() {
+        val reply = action(PostActionFamily.Reply, UiIcon.Reply)
+        val like = action(PostActionFamily.Like, UiIcon.Like)
+        val families = PostActionLayoutHelpers.allEditableFamilies.reversed()
+        val config =
+            PostActionLayoutConfig(
+                enabled = true,
+                primary = (families + families).toPersistentList(),
+            )
+
+        val result = persistentListOf(reply, like).applyPostActionLayout(config)
+
+        assertEquals(families.size, result.size)
+        families.zip(result).forEach { (family, action) ->
+            val item = assertIs<ActionMenu.Item>(action)
+            assertEquals(family, item.actionFamily)
+            when (family) {
+                PostActionFamily.Reply -> {
+                    assertEquals(reply, item)
+                }
+
+                PostActionFamily.Like -> {
+                    assertEquals(like, item)
+                }
+
+                else -> {
+                    assertFalse(item.enabled)
+                    assertEquals(ClickEvent.Noop, item.clickEvent)
+                    assertNotNull(item.icon)
+                    assertIs<ActionMenu.Item.Text.Localized>(item.text)
+                }
+            }
+        }
+        assertEquals(result, result.applyPostActionLayout(config))
+    }
+
+    @Test
+    fun unavailableActionsStayHiddenOutsideButtonRow() {
+        val families = PostActionLayoutHelpers.allEditableFamilies
+        val actions =
+            persistentListOf(
+                action(PostActionFamily.Reply, UiIcon.Reply),
+                ActionMenu.Group(
+                    displayItem = moreItem(),
+                    actions = persistentListOf(action(PostActionFamily.Share, UiIcon.Share)),
+                ),
+            )
+        val overflowConfig =
+            PostActionLayoutConfig(
+                enabled = true,
+                primary = persistentListOf(PostActionFamily.Reply),
+                overflow = families.toPersistentList(),
+            )
+        val primaryConfig = overflowConfig.copy(primary = families.toPersistentList())
+
+        listOf(
+            PostActionLayoutConfig.Default,
+            overflowConfig,
+            primaryConfig.copy(enabled = false),
+            primaryConfig.copy(
+                hidden =
+                    families
+                        .filterNot {
+                            it == PostActionFamily.Reply || it == PostActionFamily.Share
+                        }.toPersistentList(),
+                primary = families.filterNot { it == PostActionFamily.Share }.toPersistentList(),
+            ),
+        ).forEach { config ->
+            assertEquals(actions, actions.applyPostActionLayout(config))
+        }
+    }
+
+    @Test
+    fun availableTranslationActionsKeepTheirOriginalState() {
+        listOf(
+            ActionMenu.Item.Text.Localized.Type.Translate,
+            ActionMenu.Item.Text.Localized.Type.RetryTranslation,
+            ActionMenu.Item.Text.Localized.Type.ShowOriginal,
+        ).forEach { type ->
+            val translate =
+                ActionMenu.Item(
+                    icon = UiIcon.Translate,
+                    text = ActionMenu.Item.Text.Localized(type),
+                    actionFamily = PostActionFamily.Translate,
+                )
+            val actions = persistentListOf(ActionMenu.Group(displayItem = moreItem(), actions = persistentListOf(translate)))
+            val result =
+                actions.applyPostActionLayout(
+                    PostActionLayoutConfig(enabled = true, primary = persistentListOf(PostActionFamily.Translate)),
+                )
+
+            val displayed = assertIs<ActionMenu.Item>(result.single())
+            assertEquals(translate, displayed)
+            assertTrue(displayed.enabled)
+        }
     }
 
     private fun action(

--- a/social/vvo/src/commonTest/kotlin/dev/dimension/flare/ui/model/mapper/VVORenderTest.kt
+++ b/social/vvo/src/commonTest/kotlin/dev/dimension/flare/ui/model/mapper/VVORenderTest.kt
@@ -148,10 +148,20 @@ class VVORenderTest {
         val actions = post.actions.applyPostActionLayout(config)
 
         assertEquals(
-            listOf(PostActionFamily.Comment, PostActionFamily.Quote, PostActionFamily.Like),
+            listOf(
+                PostActionFamily.Reply,
+                PostActionFamily.Comment,
+                PostActionFamily.Quote,
+                PostActionFamily.Like,
+                PostActionFamily.React,
+            ),
             actions.map { assertIs<ActionMenu.Item>(it).actionFamily },
         )
-        assertEquals(quote, actions[1])
+        assertEquals(
+            listOf(PostActionFamily.Reply, PostActionFamily.React),
+            actions.filterIsInstance<ActionMenu.Item>().filterNot { it.enabled }.map { it.actionFamily },
+        )
+        assertEquals(quote, actions[2])
 
         val hiddenConfig = PostActionLayoutHelpers.moveTo(config, PostActionFamily.Repost, PostActionPlacement.Hidden)
         assertEquals(


### PR DESCRIPTION
Moving Translate into the bottom action row makes it disappear on posts without text. Custom post layouts now retain configured but unavailable actions as disabled buttons, using the same fallback for every action family. Overflow and hidden-action filtering keep their existing behavior.

Propagate the enabled state through Compose, SwiftUI, and UIKit controls. Keep iOS and macOS profile toolbars out of post layout customization so they do not gain unrelated disabled post actions.

Validation:
- All 9 related shared JVM tests pass, covering empty-post translation, unavailable action families, ordering, deduplication, repeated layout application, and overflow/hidden behavior.
- Kotlin formatting and lint checks pass for the affected shared and Compose source sets.
- Compose Android and desktop compilation passes.
- Swift syntax parsing passes for all four changed Swift files; full Apple app builds and interactive UI checks were not run.
