### PR TITLE
fix(android): remove lingering media dismissal scrim

### DIFF
--- a/app/src/main/java/dev/dimension/flare/ui/screen/media/StatusMediaScreen.kt
+++ b/app/src/main/java/dev/dimension/flare/ui/screen/media/StatusMediaScreen.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.ClipData
 import android.content.Context
 import android.os.Build
+import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
@@ -78,9 +79,11 @@ import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogWindowProvider
 import androidx.media3.common.C
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
@@ -231,6 +234,11 @@ internal fun MediaViewerScreen(
     status: UiTimelineV2.Post? = null,
     surfaceBindingManager: SurfaceBindingManager = koinInject(),
 ) {
+    val view = LocalView.current
+    LaunchedEffect(view) {
+        // The background fades with the swipe; the window dim would linger until dismissal.
+        (view.parent as? DialogWindowProvider)?.window?.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+    }
     val scope = rememberCoroutineScope()
     val clipboard = LocalClipboard.current
     val isBigScreen = currentWindowAdaptiveInfoV2().windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_LARGE_LOWER_BOUND)


### PR DESCRIPTION
Swiping to dismiss the Android media viewer could leave a dark overlay for about 300 ms after the image left the screen. Clear the media Dialog's `FLAG_DIM_BEHIND` so the existing Compose background controls the fade throughout the gesture.

Validation:
- Android debug build passed.
- Ran `:app:ktlintFormat` restricted to the changed file; formatting passed without additional changes.
- Verified slow and fast upward swipes, downward dismissal, system back, and the close button on the Android phone emulator. Recorded upward swipes showed 0–17 ms of dark background pause after the image disappeared, compared with 250–380 ms before the fix.